### PR TITLE
fix: obstacle segmentation frame result

### DIFF
--- a/driving_log_replayer/scripts/obstacle_segmentation_evaluator_node.py
+++ b/driving_log_replayer/scripts/obstacle_segmentation_evaluator_node.py
@@ -182,7 +182,12 @@ class ObstacleSegmentationResult(ResultBase):
                 self.__detection_warn += 1
             else:
                 self.__detection_total += 1
-                if len(frame_result.detection_fail_results) == 0 and topic_rate:
+                # Failure if there is no point cloud and no success
+                if (
+                    len(frame_result.detection_fail_results) == 0
+                    and len(frame_result.detection_success_results) != 0
+                    and topic_rate
+                ):
                     result = "Success"
                     self.__detection_success += 1
 


### PR DESCRIPTION
## Types of PR

- [x] Bugfix

## Description

1. restore `Fail` status for frame result
2. delete meaningless frame result log
3. fix detection judgement logic 

## How to review this PR

### Fixed "Skipped" on failure to "Fail".

https://github.com/tier4/driving_log_replayer/pull/37/files#diff-ff1376ca5c216f98f52bc448aac14bec473700dc2cebb15fc13d3db02793ad48R270

https://github.com/tier4/driving_log_replayer/pull/37/files#diff-ff1376ca5c216f98f52bc448aac14bec473700dc2cebb15fc13d3db02793ad48R179

### When non_detection succeeds, the log is no longer outputted because it is meaningless to output it.

 If NonDetection is success, Info must be NumPoints is 0 and Distances are all 0.
So, if NonDetection is success, output empty list for `Info`

```json
            "NonDetection": {
                "Result": "Success",
                "Info": [] // ←empty list
            },
```

### The success of detection was determined by the fact that the list of failures was 0, but when there were no point clouds (success was also 0), it was assumed to be a success, so the condition was changed.

https://github.com/tier4/driving_log_replayer/pull/37/files#diff-ff1376ca5c216f98f52bc448aac14bec473700dc2cebb15fc13d3db02793ad48R188

```json
            "Detection": {
                "Result": "Fail",
                "Info": [] // ←this means no pointcloud
            },
```

## Others

[bug.json.txt](https://github.com/tier4/driving_log_replayer/files/9989452/bug.json.txt)

[fixed.json.txt](https://github.com/tier4/driving_log_replayer/files/9989455/fixed.json.txt)

