### PR TITLE
feat: cli kill zombie process

### DIFF
--- a/driving_log_replayer_cli/simulation/generate.py
+++ b/driving_log_replayer_cli/simulation/generate.py
@@ -53,11 +53,11 @@ class TestScriptGenerator:
                     if command is not None:
                         generated_cmd += command + "\n"
                         # kill zombie ros2 process
-                        generated_cmd += "ps aux | grep ros2 | grep -v grep | awk '{ print \"kill -9\", $2 }' | sh"
+                        generated_cmd += "ps aux | grep ros2 | grep -v grep | awk '{ print \"kill -9\", $2 }' | sh\n"
                         # kill rviz
-                        generated_cmd += "ps aux | grep rviz | grep -v grep | awk '{ print \"kill -9\", $2 }' | sh"
+                        generated_cmd += "ps aux | grep rviz | grep -v grep | awk '{ print \"kill -9\", $2 }' | sh\n"
                         # sleep 1 sec
-                        generated_cmd += "sleep 1"
+                        generated_cmd += "sleep 1\n"
             with open(self.script_path, "w") as f:
                 f.write(generated_cmd)
             return True

--- a/driving_log_replayer_cli/simulation/generate.py
+++ b/driving_log_replayer_cli/simulation/generate.py
@@ -53,7 +53,7 @@ class TestScriptGenerator:
                     if command is not None:
                         generated_cmd += command + "\n"
                         # kill zombie ros2 process
-                        generated_cmd += "ps aux | grep ros2 | grep -v grep | awk '{ print \"kill -9\", $2 }' | sh\n"
+                        generated_cmd += "ps aux | grep -i ros | grep -v Microsoft | grep -v ros2_daemon | grep -v grep | awk '{ print \"kill -9\", $2 }' | sh"
                         # kill rviz
                         generated_cmd += "ps aux | grep rviz | grep -v grep | awk '{ print \"kill -9\", $2 }' | sh\n"
                         # sleep 1 sec

--- a/driving_log_replayer_cli/simulation/generate.py
+++ b/driving_log_replayer_cli/simulation/generate.py
@@ -52,6 +52,12 @@ class TestScriptGenerator:
                     command = self.__parse_scenario(dataset_path)
                     if command is not None:
                         generated_cmd += command + "\n"
+                        # kill zombie ros2 process
+                        generated_cmd += "ps aux | grep ros2 | grep -v grep | awk '{ print \"kill -9\", $2 }' | sh"
+                        # kill rviz
+                        generated_cmd += "ps aux | grep rviz | grep -v grep | awk '{ print \"kill -9\", $2 }' | sh"
+                        # sleep 1 sec
+                        generated_cmd += "sleep 1"
             with open(self.script_path, "w") as f:
                 f.write(generated_cmd)
             return True


### PR DESCRIPTION
## Types of PR

- [x] New Features

## Description

There is a problem with the launch termination process not killing the process and causing it to become a zombie when tests are run continuously from CLI.
Added process to kill the process from the shell.

## How to review this PR

## Others
