### PR TITLE
fix: kill bash and sh command

### DIFF
--- a/driving_log_replayer_cli/simulation/generate.py
+++ b/driving_log_replayer_cli/simulation/generate.py
@@ -53,7 +53,7 @@ class TestScriptGenerator:
                     if command is not None:
                         generated_cmd += command + "\n"
                         # kill zombie ros2 process
-                        generated_cmd += "ps aux | grep -i ros | grep -v Microsoft | grep -v ros2_daemon | grep -v grep | awk '{ print \"kill -9\", $2 }' | sh\n"
+                        generated_cmd += "ps aux | grep -i ros | grep -v Microsoft | grep -v ros2_daemon | grep -v grep | grep -v /bin/sh | grep -v /bin/bash |awk '{ print \"kill -9\", $2 }' | sh\n"
                         # kill rviz
                         generated_cmd += "ps aux | grep rviz | grep -v grep | awk '{ print \"kill -9\", $2 }' | sh\n"
                         # sleep 1 sec


### PR DESCRIPTION
## Types of PR

- [x] Bugfix

## Description

If output directory include the string `ros`, the command terminates the bash itself.
Excluding /bin/bash and /bin/sh from the target so that the process does not die

```shell
❯ ps aux | grep -i ros
hyt         7603  0.0  0.0   2892   940 pts/0    S+   02:52   0:00 /bin/sh -c /bin/bash /home/hyt/out/rosdlr_out/2022-1207-025258/run.bash
hyt         7604  0.0  0.0  11932  4428 pts/0    S+   02:52   0:00 /bin/bash /home/hyt/out/rosdlr_out/2022-1207-025258/run.bash
```


## How to review this PR

## Others
