### PR TITLE
fix: kill process unrelated to ros2

### DIFF
--- a/driving_log_replayer_cli/simulation/generate.py
+++ b/driving_log_replayer_cli/simulation/generate.py
@@ -53,11 +53,11 @@ class TestScriptGenerator:
                     if command is not None:
                         generated_cmd += command + "\n"
                         # kill zombie ros2 process
-                        generated_cmd += "pgrep ros | awk '{ print \"kill -9 $(pgrep -P \", $1, \") > /dev/null 2>&1\" }' | sh\n"
-                        generated_cmd += "pgrep ros | awk '{ print \"kill -9 \", $1, \" > /dev/null 2>&1\" }' | sh\n"
+                        generated_cmd += 'pgrep ros | awk \'{ print "kill -9 $(pgrep -P ", $1, ") > /dev/null 2>&1" }\' | sh\n'
+                        generated_cmd += 'pgrep ros | awk \'{ print "kill -9 ", $1, " > /dev/null 2>&1" }\' | sh\n'
                         # kill rviz awk '{ print \"kill -9\", $2 }'
-                        generated_cmd += "pgrep rviz | awk '{ print \"kill -9 $(pgrep -P \", $1, \") > /dev/null 2>&1\" }' | sh\n"
-                        generated_cmd += "pgrep rviz | awk '{ print \"kill -9 \", $1, \" > /dev/null 2>&1\" }' | sh\n"
+                        generated_cmd += 'pgrep rviz | awk \'{ print "kill -9 $(pgrep -P ", $1, ") > /dev/null 2>&1" }\' | sh\n'
+                        generated_cmd += 'pgrep rviz | awk \'{ print "kill -9 ", $1, " > /dev/null 2>&1" }\' | sh\n'
                         # sleep 1 sec
                         generated_cmd += "sleep 1\n"
             with open(self.script_path, "w") as f:

--- a/driving_log_replayer_cli/simulation/generate.py
+++ b/driving_log_replayer_cli/simulation/generate.py
@@ -53,9 +53,11 @@ class TestScriptGenerator:
                     if command is not None:
                         generated_cmd += command + "\n"
                         # kill zombie ros2 process
-                        generated_cmd += "ps aux | grep -i ros | grep -v Microsoft | grep -v ros2_daemon | grep -v grep | grep -v /bin/sh | grep -v /bin/bash |awk '{ print \"kill -9\", $2 }' | sh\n"
-                        # kill rviz
-                        generated_cmd += "ps aux | grep rviz | grep -v grep | awk '{ print \"kill -9\", $2 }' | sh\n"
+                        generated_cmd += "pgrep ros | awk '{ print \"kill -9 $(pgrep -P \", $1, \") > /dev/null 2>&1\" }' | sh\n"
+                        generated_cmd += "pgrep ros | awk '{ print \"kill -9 \", $1, \" > /dev/null 2>&1\" }' | sh\n"
+                        # kill rviz awk '{ print \"kill -9\", $2 }'
+                        generated_cmd += "pgrep rviz | awk '{ print \"kill -9 $(pgrep -P \", $1, \") > /dev/null 2>&1\" }' | sh\n"
+                        generated_cmd += "pgrep rviz | awk '{ print \"kill -9 \", $1, \" > /dev/null 2>&1\" }' | sh\n"
                         # sleep 1 sec
                         generated_cmd += "sleep 1\n"
             with open(self.script_path, "w") as f:


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Description
### Issue
driving_log_replayer kills the process unrelated to ros2, that is including "ros" charactors in the line of `ps aux` outputs.
ex. /home/masahi**ros**akamoto/..
### Countermeasure
To extract only the child processes that name include "ros", "pgrep" is used.

## How to review this PR
- Check the code changes.
- Checkout this branch, reinstall driving_log_reolayer and run it to check if any degradation occurs when driving_log_reolayer closes.
- Adding above, after running the process that name includes "ros" (ex. run ros.sh),  run driving_log_replayer to check if the process keeps running when driving_log_reolayer closes.

### Results
- Any degradation occurred after applying this changes.
- "ros_check_if_alive.sh" process kept running after driving_log_reolayer closed.
[check_if_unrelated_process_alive.log](https://github.com/tier4/driving_log_replayer/files/10432405/check_if_unrelated_process_alive.log)


## Others
