### PR TITLE
feat: #147 perception 2d support multi camera

### DIFF
--- a/docs/use_case/perception_2d.en.md
+++ b/docs/use_case/perception_2d.en.md
@@ -4,8 +4,6 @@ The performance of Autoware's recognition function (perception) is evaluated by 
 
 Run the perception module and pass the output perception topic to the evaluation library for evaluation.
 
-Currently, only one camera is supported.
-
 ## Preparation
 
 ### Model conversion
@@ -92,33 +90,6 @@ index b697b1f50..b9cb53102 100644
      <param name="model_path" value="$(var model_path)/$(var model_name).onnx"/>
 ```
 
-Currently, only camera No.0 can be evaluated, so if you want to evaluate other cameras, swap the camera numbers. The following example shows how to swap 0 and 3
-
-```shell
---- a/launch/tier4_perception_launch/launch/perception.launch.xml
-+++ b/launch/tier4_perception_launch/launch/perception.launch.xml
-@@ -17,14 +17,14 @@
-   <arg name="input/pointcloud" default="/sensing/lidar/concatenated/pointcloud" description="The topic will be used in the detection module"/>
-   <arg name="mode" default="camera_lidar_fusion" description="options: `camera_lidar_radar_fusion`, `camera_lidar_fusion`, `lidar_radar_fusion`, `lidar` or `radar`"/>
-   <arg name="lidar_detection_model" default="centerpoint" description="options: `centerpoint`, `apollo`, `pointpainting`, `clustering`"/>
--  <arg name="image_raw0" default="/sensing/camera/camera0/image_rect_color" description="image raw topic name"/>
--  <arg name="camera_info0" default="/sensing/camera/camera0/camera_info" description="camera info topic name"/>
-+  <arg name="image_raw0" default="/sensing/camera/camera3/image_rect_color" description="image raw topic name"/>
-+  <arg name="camera_info0" default="/sensing/camera/camera3/camera_info" description="camera info topic name"/>
-   <arg name="image_raw1" default="/sensing/camera/camera1/image_rect_color"/>
-   <arg name="camera_info1" default="/sensing/camera/camera1/camera_info"/>
-   <arg name="image_raw2" default="/sensing/camera/camera2/image_rect_color"/>
-   <arg name="camera_info2" default="/sensing/camera/camera2/camera_info"/>
--  <arg name="image_raw3" default="/sensing/camera/camera3/image_rect_color"/>
--  <arg name="camera_info3" default="/sensing/camera/camera3/camera_info"/>
-+  <arg name="image_raw3" default="/sensing/camera/camera0/image_rect_color"/>
-+  <arg name="camera_info3" default="/sensing/camera/camera0/camera_info"/>
-   <arg name="image_raw4" default="/sensing/camera/camera4/image_rect_color"/>
-   <arg name="camera_info4" default="/sensing/camera/camera4/camera_info"/>
-   <arg name="image_raw5" default="/sensing/camera/camera5/image_rect_color"/>
-@@ -33,7 +33,7 @@
-```
-
 ## Evaluation method
 
 The perception_2d evaluation is executed by launching the `perception_2d.launch.py` file.
@@ -126,7 +97,7 @@ Launching the file executes the following steps:
 
 1. Execute launch of evaluation node (`perception_2d_evaluator_node`), `logging_simulator.launch` file and `ros2 bag play` command
 2. Autoware receives sensor data output from input rosbag and outputs camera, and the perception module performs recognition.
-3. The evaluation node subscribes to `/perception/object_recognition/detection{/detected}/rois0` and evaluates data. The result is dumped into a file.
+3. The evaluation node subscribes to `/perception/object_recognition/detection{/detected}/rois{camera_no}` and evaluates data. The result is dumped into a file.
 4. When the playback of the rosbag is finished, Autoware's launch is automatically terminated, and the evaluation is completed.
 
 ## Evaluation results
@@ -148,10 +119,10 @@ The perception evaluation output is marked as `Error` when condition for `Normal
 
 Subscribed topics:
 
-| Topic name                                             | Data type                                            |
-| ------------------------------------------------------ | ---------------------------------------------------- |
-| /perception/object_recognition/detection/rois0         | tier4_perception_msgs/msg/DetectedObjectsWithFeature |
-| /perception/object_recognition/detection/tracked/rois0 | tier4_perception_msgs/msg/DetectedObjectsWithFeature |
+| Topic name                                                       | Data type                                            |
+| ---------------------------------------------------------------- | ---------------------------------------------------- |
+| /perception/object_recognition/detection/rois{camera_no}         | tier4_perception_msgs/msg/DetectedObjectsWithFeature |
+| /perception/object_recognition/detection/tracked/rois{camera_no} | tier4_perception_msgs/msg/DetectedObjectsWithFeature |
 
 Published topics:
 
@@ -268,6 +239,7 @@ Format of each frame:
 ```json
 {
   "Frame": {
+    "CameraType": "Evaluated camera",
     "FrameName": "Frame number of t4_dataset used for evaluation",
     "FrameSkip": "Number of times that an object was requested to be evaluated but the evaluation was skipped because there was no ground truth in the dataset within 75msec",
     "PassFail": {

--- a/driving_log_replayer/scripts/perception_2d_evaluator_node.py
+++ b/driving_log_replayer/scripts/perception_2d_evaluator_node.py
@@ -97,7 +97,7 @@ class Perception2DResult(ResultBase):
         self.__total = {}
         self.__result = {}
         self.__msg = {}
-        for camera_type, _ in self.__target_cameras.items():
+        for camera_type in self.__target_cameras.keys():
             self.__success[camera_type] = 0
             self.__total[camera_type] = 0
             self.__result[camera_type] = True

--- a/driving_log_replayer/scripts/perception_2d_evaluator_node.py
+++ b/driving_log_replayer/scripts/perception_2d_evaluator_node.py
@@ -106,13 +106,13 @@ class Perception2DResult(ResultBase):
     def update(self):
         summary_str = ""
         for camera_type, eval_msg in self.__msg.items():
-            summary_str += f"{camera_type}: {eval_msg}"
+            summary_str += f" {camera_type}: {eval_msg}"
         if all(self.__result.values()):  # if all camera results are True
             self._success = True
-            self._summary = f"Passed: {summary_str}"
+            self._summary = f"Passed:{summary_str}"
         else:
             self._success = False
-            self._summary = f"Failed: {summary_str}"
+            self._summary = f"Failed:{summary_str}"
 
     def add_frame(
         self,
@@ -142,7 +142,7 @@ class Perception2DResult(ResultBase):
         self.__result[camera_type] = test_rate >= self.__pass_rate
         self.__msg[
             camera_type
-        ] = f"{ self.__success[camera_type] } / {self.__total[camera_type] } -> {test_rate:.2f}%"
+        ] = f"{self.__success[camera_type]} / {self.__total[camera_type]} -> {test_rate:.2f}%"
 
         out_frame = {
             "CameraType": camera_type,
@@ -338,7 +338,7 @@ class Perception2DEvaluator(Node):
         return estimated_objects
 
     def detected_objs_cb(self, msg: DetectedObjectsWithFeature, camera_type: str):
-        self.get_logger().error(f"{camera_type} callback")
+        # self.get_logger().error(f"{camera_type} callback")
         map_to_baselink = self.__tf_buffer.lookup_transform("map", "base_link", msg.header.stamp)
         unix_time: int = eval_conversions.unix_time_from_ros_msg(msg.header)
         # 現frameに対応するGround truthを取得

--- a/driving_log_replayer/scripts/perception_2d_evaluator_node.py
+++ b/driving_log_replayer/scripts/perception_2d_evaluator_node.py
@@ -145,7 +145,7 @@ class Perception2DResult(ResultBase):
         ] = f"{ self.__success[camera_type] } / {self.__total[camera_type] } -> {test_rate:.2f}%"
 
         out_frame = {
-            "CemaraType": camera_type,
+            "CamaraType": camera_type,
             "Ego": {"TransformStamped": map_to_baselink},
             "FrameName": frame.frame_name,
             "FrameSkip": skip,

--- a/driving_log_replayer/scripts/perception_2d_evaluator_node.py
+++ b/driving_log_replayer/scripts/perception_2d_evaluator_node.py
@@ -145,7 +145,7 @@ class Perception2DResult(ResultBase):
         ] = f"{ self.__success[camera_type] } / {self.__total[camera_type] } -> {test_rate:.2f}%"
 
         out_frame = {
-            "CamaraType": camera_type,
+            "CameraType": camera_type,
             "Ego": {"TransformStamped": map_to_baselink},
             "FrameName": frame.frame_name,
             "FrameSkip": skip,

--- a/driving_log_replayer/scripts/perception_2d_evaluator_node.py
+++ b/driving_log_replayer/scripts/perception_2d_evaluator_node.py
@@ -258,7 +258,7 @@ class Perception2DEvaluator(Node):
             self.__subscribers[camera_type] = self.create_subscription(
                 DetectedObjectsWithFeature,
                 self.get_topic_name(evaluation_task, camera_no),
-                lambda msg: self.detected_objs_cb(msg, camera_type),
+                lambda msg, local_type=camera_type: self.detected_objs_cb(msg, local_type),
                 1,
             )
             self.__skip_counter[camera_type] = 0

--- a/driving_log_replayer/scripts/perception_evaluator_node.py
+++ b/driving_log_replayer/scripts/perception_evaluator_node.py
@@ -280,7 +280,9 @@ class PerceptionEvaluator(Node):
         )  # wall timer
         self.__skip_counter = 0
 
-    def get_frame_id_and_msg_type(self, evaluation_task: str) -> Tuple[str, Union[DetectedObjects, TrackedObjects]]:
+    def get_frame_id_and_msg_type(
+        self, evaluation_task: str
+    ) -> Tuple[str, Union[DetectedObjects, TrackedObjects]]:
         if evaluation_task == "detection":
             return "base_link", DetectedObjects
         elif evaluation_task == "tracking":

--- a/driving_log_replayer/scripts/perception_evaluator_node.py
+++ b/driving_log_replayer/scripts/perception_evaluator_node.py
@@ -280,7 +280,7 @@ class PerceptionEvaluator(Node):
         )  # wall timer
         self.__skip_counter = 0
 
-    def get_frame_id_and_msg_type(self, evaluation_task: str):
+    def get_frame_id_and_msg_type(self, evaluation_task: str) -> Tuple[str, Union[DetectedObjects, TrackedObjects]]:
         if evaluation_task == "detection":
             return "base_link", DetectedObjects
         elif evaluation_task == "tracking":

--- a/driving_log_replayer_cli/simulation/generate.py
+++ b/driving_log_replayer_cli/simulation/generate.py
@@ -52,6 +52,8 @@ class TestScriptGenerator:
                     command = self.__parse_scenario(dataset_path)
                     if command is not None:
                         generated_cmd += command + "\n"
+                        # echo return value of ros2 launch
+                        generated_cmd += "echo $?\n"
                         # kill zombie ros2 process
                         generated_cmd += 'pgrep ros | awk \'{ print "kill -9 $(pgrep -P ", $1, ") > /dev/null 2>&1" }\' | sh\n'
                         generated_cmd += 'pgrep ros | awk \'{ print "kill -9 ", $1, " > /dev/null 2>&1" }\' | sh\n'

--- a/sample/perception_2d/scenario.ja.yaml
+++ b/sample/perception_2d/scenario.ja.yaml
@@ -13,10 +13,10 @@ Evaluation:
         LocalMapPath: $HOME/map/perception # データセット毎にLocalMapPathを指定する
   Conditions:
     PassRate: 99.0 # 評価試行回数の内、どの程度(%)評価成功だったら成功とするか
-  PerceptionEvaluationConfig:
-    camera_types: # 評価対象のカメラの種類をキーに、カメラの番号を値として記述する
+    TargetCameras: # 評価対象のカメラの種類をキーに、カメラの番号を値として記述する
       cam_front: 0
       cam_front_right: 1
+  PerceptionEvaluationConfig:
     evaluation_config_dict:
       evaluation_task: detection2d # detection2d # 現時点ではdetection2dにしか対応していない。今後の拡張でtracking2dにも対応予定
       target_labels: [car, truck, bicycle, pedestrian, motorbike] # 評価ラベル

--- a/sample/perception_2d/scenario.ja.yaml
+++ b/sample/perception_2d/scenario.ja.yaml
@@ -14,8 +14,8 @@ Evaluation:
   Conditions:
     PassRate: 99.0 # 評価試行回数の内、どの程度(%)評価成功だったら成功とするか
   PerceptionEvaluationConfig:
-    camera_type: cam_front # /perception/object_recognition/detection/rois0に出力されるカメラのタイプを指定する。
-    camera_mapping: # 現状は1台にしか対応してないのでここは使用されない。今後の拡張用
+    camera_type: [cam_front, cam_front_right] # 評価対象のカメラを配列で記述する
+    camera_mapping: # Describes the correspondence between the number and type of CAMERA installed in the vehicle.
       camera0: cam_front
       camera1: cam_front_right
       camera2: cam_back_right

--- a/sample/perception_2d/scenario.ja.yaml
+++ b/sample/perception_2d/scenario.ja.yaml
@@ -14,14 +14,9 @@ Evaluation:
   Conditions:
     PassRate: 99.0 # 評価試行回数の内、どの程度(%)評価成功だったら成功とするか
   PerceptionEvaluationConfig:
-    camera_type: [cam_front, cam_front_right] # 評価対象のカメラを配列で記述する
-    camera_mapping: # Describes the correspondence between the number and type of CAMERA installed in the vehicle.
-      camera0: cam_front
-      camera1: cam_front_right
-      camera2: cam_back_right
-      camera3: cam_back
-      camera4: cam_back_left
-      camera5: cam_front_left
+    camera_types: # 評価対象のカメラの種類をキーに、カメラの番号を値として記述する
+      cam_front: 0
+      cam_front_right: 1
     evaluation_config_dict:
       evaluation_task: detection2d # detection2d # 現時点ではdetection2dにしか対応していない。今後の拡張でtracking2dにも対応予定
       target_labels: [car, truck, bicycle, pedestrian, motorbike] # 評価ラベル

--- a/sample/perception_2d/scenario.yaml
+++ b/sample/perception_2d/scenario.yaml
@@ -13,7 +13,7 @@ Evaluation:
         LocalMapPath: $HOME/map/perception # Specify LocalMapPath for each data set.
   Conditions:
     PassRate: 99.0 # How much (%) of the evaluation attempts are considered successful.
-    TargetCameras: # Describe the cameras to be evaluated
+    TargetCameras: # Describes the type of camera to be evaluated as a key and the camera number as a value.
       cam_front: 0
       cam_front_right: 1
   PerceptionEvaluationConfig:

--- a/sample/perception_2d/scenario.yaml
+++ b/sample/perception_2d/scenario.yaml
@@ -14,14 +14,9 @@ Evaluation:
   Conditions:
     PassRate: 99.0 # How much (%) of the evaluation attempts are considered successful.
   PerceptionEvaluationConfig:
-    camera_type: [cam_front, cam_front_right] # Describe the cameras to be evaluated in an array.
-    camera_mapping: # Currently only one unit is supported, so this area is not used. For future expansion
-      camera0: cam_front
-      camera1: cam_front_right
-      camera2: cam_back_right
-      camera3: cam_back
-      camera4: cam_back_left
-      camera5: cam_front_left
+    camera_types: # Describe the cameras to be evaluated in an array adn describe camera no
+      cam_front: 0
+      cam_front_right: 1
     evaluation_config_dict:
       evaluation_task: detection2d # detection2d # At present, only detection2d is supported. tracking2d will be supported in future extensions.
       target_labels: [car, truck, bicycle, pedestrian, motorbike] # evaluation label

--- a/sample/perception_2d/scenario.yaml
+++ b/sample/perception_2d/scenario.yaml
@@ -13,10 +13,10 @@ Evaluation:
         LocalMapPath: $HOME/map/perception # Specify LocalMapPath for each data set.
   Conditions:
     PassRate: 99.0 # How much (%) of the evaluation attempts are considered successful.
-  PerceptionEvaluationConfig:
-    camera_types: # Describe the cameras to be evaluated in an array adn describe camera no
+    TargetCameras: # Describe the cameras to be evaluated
       cam_front: 0
       cam_front_right: 1
+  PerceptionEvaluationConfig:
     evaluation_config_dict:
       evaluation_task: detection2d # detection2d # At present, only detection2d is supported. tracking2d will be supported in future extensions.
       target_labels: [car, truck, bicycle, pedestrian, motorbike] # evaluation label

--- a/sample/perception_2d/scenario.yaml
+++ b/sample/perception_2d/scenario.yaml
@@ -14,7 +14,7 @@ Evaluation:
   Conditions:
     PassRate: 99.0 # How much (%) of the evaluation attempts are considered successful.
   PerceptionEvaluationConfig:
-    camera_type: cam_front # Specifies the type of camera output in /perception/object_recognition/detection/rois0.
+    camera_type: [cam_front, cam_front_right] # Describe the cameras to be evaluated in an array.
     camera_mapping: # Currently only one unit is supported, so this area is not used. For future expansion
       camera0: cam_front
       camera1: cam_front_right


### PR DESCRIPTION
## Types of PR

- [x] New Features

## Description

- support multiple cameras in perception_2d
- https://github.com/tier4/autoware_perception_evaluation/pull/64

## How to review this PR

output result likes below.

## Others

```shell
[perception_2d_evaluator_node.py-66]  Skipped Frames Count: 201
[perception_2d_evaluator_node.py-66] 
[perception_2d_evaluator_node.py-66] Ground Truth Num: 6962
[perception_2d_evaluator_node.py-66] 
[perception_2d_evaluator_node.py-66] mAP: 0.060 (Center Distance)
[perception_2d_evaluator_node.py-66] 
[perception_2d_evaluator_node.py-66] |      Label | car(100) |  bicycle(100) |  pedestrian(100) |  motorbike(100) | 
[perception_2d_evaluator_node.py-66] | :--------: | :---: | :---: | :---: | :---: |
[perception_2d_evaluator_node.py-66] | Predict_num | 1174 | 0 | 66 | 0 |
[perception_2d_evaluator_node.py-66] |         AP | 0.196 |  0.000 |  0.045 |  0.000 | 
[perception_2d_evaluator_node.py-66] 
[perception_2d_evaluator_node.py-66] mAP: 0.062 (Center Distance)
[perception_2d_evaluator_node.py-66] 
[perception_2d_evaluator_node.py-66] |      Label | car(200) |  bicycle(200) |  pedestrian(200) |  motorbike(200) | 
[perception_2d_evaluator_node.py-66] | :--------: | :---: | :---: | :---: | :---: |
[perception_2d_evaluator_node.py-66] | Predict_num | 1174 | 0 | 66 | 0 |
[perception_2d_evaluator_node.py-66] |         AP | 0.202 |  0.000 |  0.045 |  0.000 | 
[perception_2d_evaluator_node.py-66] 
[perception_2d_evaluator_node.py-66] mAP: 0.039 (IoU 2D)
[perception_2d_evaluator_node.py-66] 
[perception_2d_evaluator_node.py-66] |      Label | car(0.5) |  bicycle(0.5) |  pedestrian(0.5) |  motorbike(0.5) | 
[perception_2d_evaluator_node.py-66] | :--------: | :---: | :---: | :---: | :---: |
[perception_2d_evaluator_node.py-66] | Predict_num | 1174 | 0 | 66 | 0 |
[perception_2d_evaluator_node.py-66] |         AP | 0.153 |  0.000 |  0.001 |  0.000 | 
[perception_2d_evaluator_node.py-66] 

...

<< show test result >>
test case 1 / 1 : use case: sample
--------------------------------------------------
TestResult: Failed
Failed: cam_front: 0 / 201 -> 0.00% cam_front_right: 0 / 200 -> 0.00%
```
