### PR TITLE
fix: fill z value of initial pose

### DIFF
--- a/sample/localization/scenario.ja.yaml
+++ b/sample/localization/scenario.ja.yaml
@@ -22,7 +22,7 @@ Evaluation:
     position:
       x: 3836.5478515625
       y: 73729.96875
-      z: 0.0
+      z: 20.0
     orientation:
       x: 0.0
       y: 0.0

--- a/sample/localization/scenario.yaml
+++ b/sample/localization/scenario.yaml
@@ -22,7 +22,7 @@ Evaluation:
     position:
       x: 3836.5478515625
       y: 73729.96875
-      z: 0.0
+      z: 20.0
     orientation:
       x: 0.0
       y: 0.0


### PR DESCRIPTION
 Automatic correction of z-coordinates is not working, so I set the z value appropriately.
 https://github.com/autowarefoundation/autoware.universe/pull/2724

## Types of PR

- [x] Upgrade of existing features

## Description

- fill z value

## How to review this PR

## Others
