### PR TITLE
feat: add support of dump data to pickle with `dump_to_pkl` function

### DIFF
--- a/driving_log_replayer/driving_log_replayer/result.py
+++ b/driving_log_replayer/driving_log_replayer/result.py
@@ -15,9 +15,9 @@
 # limitations under the License.
 
 import os
-import pickle
 from typing import Dict
 
+from perception_eval.util.file import dump_to_pkl
 from rclpy.clock import Clock
 from rclpy.clock import ClockType
 import simplejson as json
@@ -90,7 +90,7 @@ class PickleWriter:
         self._pickle_file = open(os.path.expandvars(out_pkl_path), "wb")
 
     def dump(self, write_object):
-        pickle.dump(write_object, self._pickle_file)
+        dump_to_pkl(write_object, self._pickle_file)
         self.close()
 
     def close(self):


### PR DESCRIPTION
## Types of PR

- [x] Upgrade of existing features

## Description

As described in https://github.com/tier4/driving_log_replayer/issues/181, this PR add support of saving `scene_result.pkl` with version information.

- If users want to load old pkl file, `load_pkl()` warns deprecated format.
- If users load pkl file that has invalid major or minor version compared to version of using perception_eval, load_pkl() raises ValueError.

## How to review this PR

1. Run driving_log_replayer.
2. Check whether version information is contained in serialized pkl.
3. Check if it is possible to load both of old and new pkl with `perception_eval.util.load_pkl()`.

## Others
