### PR TITLE
feat: yabloc test

### DIFF
--- a/driving_log_replayer/driving_log_replayer/yabloc.py
+++ b/driving_log_replayer/driving_log_replayer/yabloc.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2023 TIER IV.inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+from typing import ClassVar
+
+from diagnostic_msgs.msg import DiagnosticArray
+
+from driving_log_replayer.result import ResultBase
+from driving_log_replayer.result import TopicResult
+
+
+@dataclass
+class AvailabilityResult(TopicResult):
+    name: ClassVar[str] = "NDT Availability"
+    TARGET_DIAG_NAME: ClassVar[str] = "yabloc_monitor: yabloc_status"
+
+    def set_frame(self, msg: DiagnosticArray) -> dict:
+        include_target_status = False
+        # Check if the NDT is available. Note that it does NOT check topic rate itself, but just the availability of the topic
+        for diag_status in msg.status:
+            if diag_status.name != AvailabilityResult.TARGET_DIAG_NAME:
+                continue
+            include_target_status = True
+            values = {value.key: value.value for value in diag_status.values}
+            # Here we assume that, once a node (e.g. ndt_scan_matcher) fails, it will not be relaunched automatically.
+            # On the basis of this assumption, we only consider the latest diagnostics received.
+            # Possible status are OK, Timeout, NotReceived, WarnRate, and ErrorRate
+            if values["status"] in AvailabilityResult.ERROR_STATUS_LIST:
+                self.success = False
+                self.summary = f"{self.name} ({self.success_str()}): NDT not available"
+            else:
+                self.success = True
+                self.summary = f"{self.name} ({self.success_str()}): NDT available"
+        if include_target_status:
+            return {
+                "Availability": {
+                    "Result": self.success_str(),
+                    "Info": [
+                        {},
+                    ],
+                },
+            }
+        return {
+            "Availability": {
+                "Result": "Fail",
+                "Info": [
+                    {"Reason": "diagnostics does not contain localization_topic_status"},
+                ],
+            },
+        }
+
+
+class YabLocResult(ResultBase):
+    def __init__(self) -> None:
+        super().__init__()
+        self.__availability = AvailabilityResult()
+        # availability
+        self.__yabloc_availability_result = False
+        self.__yabloc_availability_msg = "NotTested"
+
+    def update(self) -> None:
+        if self.__yabloc_availability_result:
+            yabloc_availability_summary = (
+                f"YabLoc Availability (Passed): {self.__yabloc_availability_msg}"
+            )
+        else:
+            yabloc_availability_summary = (
+                f"YabLoc Availability (Failed): {self.__yabloc_availability_msg}"
+            )
+        summary_str = f"{yabloc_availability_summary}"
+        if self.__yabloc_availability_result:
+            self._success = True
+            self._summary = f"Passed: {summary_str}"
+        else:
+            self._success = False
+            self._summary = f"Failed: {summary_str}"
+
+    def set_frame(self, msg: DiagnosticArray) -> None:
+        for diag_status in msg.status:
+            out_frame = {"Ego": {}}
+            if diag_status.name != "yabloc_monitor: yabloc_status":
+                continue
+            values = {value.key: value.value for value in diag_status.values}
+            self.__yabloc_availability_result = values["Availability"] == "OK"
+            self.__yabloc_availability_msg = values["Availability"]
+            out_frame["Availability"] = {
+                "Result": "Success" if self.__yabloc_availability_result else "Fail",
+                "Info": [],
+            }
+            self._frame = out_frame
+            self.update()

--- a/driving_log_replayer/driving_log_replayer/yabloc.py
+++ b/driving_log_replayer/driving_log_replayer/yabloc.py
@@ -41,17 +41,15 @@ class Availability(EvaluationItem):
             return {
                 "Ego": {},
                 "Availability": {
-                    "Result": self.success_str(),
-                    "Info": [],
+                    "Result": {"Total": self.success_str(), "Frame": self.success_str()},
+                    "Info": {},
                 },
             }
         return {
             "Ego": {},
             "Availability": {
-                "Result": "Warn",
-                "Info": [
-                    {"Reason": "diagnostics does not contain yabloc_status"},
-                ],
+                "Result": {"Total": self.success_str(), "Frame": "Warn"},
+                "Info": {"Reason": "diagnostics does not contain yabloc_status"},
             },
         }
 

--- a/driving_log_replayer/driving_log_replayer/yabloc.py
+++ b/driving_log_replayer/driving_log_replayer/yabloc.py
@@ -17,19 +17,19 @@ from typing import ClassVar
 
 from diagnostic_msgs.msg import DiagnosticArray
 
+from driving_log_replayer.result import EvaluationItem
 from driving_log_replayer.result import ResultBase
-from driving_log_replayer.result import TopicResult
 
 
 @dataclass
-class AvailabilityResult(TopicResult):
+class Availability(EvaluationItem):
     name: ClassVar[str] = "Yabloc Availability"
     TARGET_DIAG_NAME: ClassVar[str] = "yabloc_monitor: yabloc_status"
 
     def set_frame(self, msg: DiagnosticArray) -> dict:
         include_target_status = False
         for diag_status in msg.status:
-            if diag_status.name != AvailabilityResult.TARGET_DIAG_NAME:
+            if diag_status.name != Availability.TARGET_DIAG_NAME:
                 continue
             include_target_status = True
             values = {value.key: value.value for value in diag_status.values}
@@ -59,7 +59,7 @@ class AvailabilityResult(TopicResult):
 class YabLocResult(ResultBase):
     def __init__(self) -> None:
         super().__init__()
-        self.__availability = AvailabilityResult()
+        self.__availability = Availability()
 
     def update(self) -> None:
         summary_str = f"{self.__availability.summary}"

--- a/driving_log_replayer/scripts/yabloc_evaluator_node.py
+++ b/driving_log_replayer/scripts/yabloc_evaluator_node.py
@@ -19,47 +19,7 @@ from diagnostic_msgs.msg import DiagnosticArray
 
 from driving_log_replayer.evaluator import DLREvaluator
 from driving_log_replayer.evaluator import evaluator_main
-from driving_log_replayer.result import ResultBase
-
-
-class YabLocResult(ResultBase):
-    def __init__(self) -> None:
-        super().__init__()
-        # availability
-        self.__yabloc_availability_result = False
-        self.__yabloc_availability_msg = "NotTested"
-
-    def update(self) -> None:
-        if self.__yabloc_availability_result:
-            yabloc_availability_summary = (
-                f"YabLoc Availability (Passed): {self.__yabloc_availability_msg}"
-            )
-        else:
-            yabloc_availability_summary = (
-                f"YabLoc Availability (Failed): {self.__yabloc_availability_msg}"
-            )
-        summary_str = f"{yabloc_availability_summary}"
-        if self.__yabloc_availability_result:
-            self._success = True
-            self._summary = f"Passed: {summary_str}"
-        else:
-            self._success = False
-            self._summary = f"Failed: {summary_str}"
-
-    def set_frame(self, msg: DiagnosticArray) -> None:
-        for diag_status in msg.status:
-            out_frame = {"Ego": {}}
-            if diag_status.name != "yabloc_monitor: yabloc_status":
-                continue
-            values = {value.key: value.value for value in diag_status.values}
-            self.__yabloc_availability_result = values["Availability"] == "OK"
-            self.__yabloc_availability_msg = values["Availability"]
-            out_frame["Availability"] = {
-                "Result": "Success" if self.__yabloc_availability_result else "Fail",
-                "Info": [],
-            }
-            self._frame = out_frame
-            self.update()
+from driving_log_replayer.yabloc import YabLocResult
 
 
 class YabLocEvaluator(DLREvaluator):

--- a/driving_log_replayer/test/unittest/test_yabloc.py
+++ b/driving_log_replayer/test/unittest/test_yabloc.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2023 TIER IV.inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from diagnostic_msgs.msg import DiagnosticArray
+from diagnostic_msgs.msg import DiagnosticStatus
+from diagnostic_msgs.msg import KeyValue
+
+from driving_log_replayer.yabloc import AvailabilityResult
+
+
+def test_availability_success() -> None:
+    status = DiagnosticStatus(
+        name=AvailabilityResult.TARGET_DIAG_NAME,
+        values=[KeyValue(key="Availability", value="OK")],
+    )
+    result = AvailabilityResult()
+    frame = result.set_frame(DiagnosticArray(status=[status]))
+    assert result.success is True
+    assert result.summary == "Yabloc Availability (Success): OK"
+    assert frame == {
+        "Ego": {},
+        "Availability": {
+            "Result": "Success",
+            "Info": [],
+        },
+    }
+
+
+def test_availability_fail() -> None:
+    status = DiagnosticStatus(
+        name=AvailabilityResult.TARGET_DIAG_NAME,
+        values=[KeyValue(key="Availability", value="NG")],
+    )
+    result = AvailabilityResult()
+    frame = result.set_frame(DiagnosticArray(status=[status]))
+    assert result.success is False
+    assert result.summary == "Yabloc Availability (Fail): NG"
+    assert frame == {
+        "Ego": {},
+        "Availability": {
+            "Result": "Fail",
+            "Info": [],
+        },
+    }
+
+
+def test_availability_fail_key_not_found() -> None:
+    status = DiagnosticStatus(
+        name=AvailabilityResult.TARGET_DIAG_NAME,
+        values=[KeyValue(key="Convergence", value="AnyValue")],
+    )
+    result = AvailabilityResult()
+    frame = result.set_frame(DiagnosticArray(status=[status]))
+    assert result.success is False
+    assert result.summary == "Yabloc Availability (Fail): Availability Key Not Found"
+    assert frame == {
+        "Ego": {},
+        "Availability": {
+            "Result": "Fail",
+            "Info": [],
+        },
+    }
+
+
+def test_availability_has_no_target_diag() -> None:
+    status = DiagnosticStatus(name="not_yabloc_status")
+    result = AvailabilityResult()
+    frame = result.set_frame(DiagnosticArray(status=[status]))
+    assert result.success is False  # default value is False
+    assert result.summary == "NotTested"
+    assert frame == {
+        "Ego": {},
+        "Availability": {
+            "Result": "Warn",
+            "Info": [
+                {"Reason": "diagnostics does not contain yabloc_status"},
+            ],
+        },
+    }

--- a/driving_log_replayer/test/unittest/test_yabloc.py
+++ b/driving_log_replayer/test/unittest/test_yabloc.py
@@ -31,8 +31,8 @@ def test_availability_success() -> None:
     assert frame == {
         "Ego": {},
         "Availability": {
-            "Result": "Success",
-            "Info": [],
+            "Result": {"Total": "Success", "Frame": "Success"},
+            "Info": {},
         },
     }
 
@@ -49,8 +49,8 @@ def test_availability_fail() -> None:
     assert frame == {
         "Ego": {},
         "Availability": {
-            "Result": "Fail",
-            "Info": [],
+            "Result": {"Total": "Fail", "Frame": "Fail"},
+            "Info": {},
         },
     }
 
@@ -67,8 +67,8 @@ def test_availability_fail_key_not_found() -> None:
     assert frame == {
         "Ego": {},
         "Availability": {
-            "Result": "Fail",
-            "Info": [],
+            "Result": {"Total": "Fail", "Frame": "Fail"},
+            "Info": {},
         },
     }
 
@@ -82,9 +82,7 @@ def test_availability_has_no_target_diag() -> None:
     assert frame == {
         "Ego": {},
         "Availability": {
-            "Result": "Warn",
-            "Info": [
-                {"Reason": "diagnostics does not contain yabloc_status"},
-            ],
+            "Result": {"Total": "Fail", "Frame": "Warn"},
+            "Info": {"Reason": "diagnostics does not contain yabloc_status"},
         },
     }

--- a/driving_log_replayer/test/unittest/test_yabloc.py
+++ b/driving_log_replayer/test/unittest/test_yabloc.py
@@ -24,11 +24,11 @@ def test_availability_success() -> None:
         name=Availability.TARGET_DIAG_NAME,
         values=[KeyValue(key="Availability", value="OK")],
     )
-    result = Availability()
-    frame = result.set_frame(DiagnosticArray(status=[status]))
-    assert result.success is True
-    assert result.summary == "Yabloc Availability (Success): OK"
-    assert frame == {
+    evaluation_item = Availability()
+    frame_dict = evaluation_item.set_frame(DiagnosticArray(status=[status]))
+    assert evaluation_item.success is True
+    assert evaluation_item.summary == "Yabloc Availability (Success): OK"
+    assert frame_dict == {
         "Ego": {},
         "Availability": {
             "Result": {"Total": "Success", "Frame": "Success"},
@@ -42,11 +42,11 @@ def test_availability_fail() -> None:
         name=Availability.TARGET_DIAG_NAME,
         values=[KeyValue(key="Availability", value="NG")],
     )
-    result = Availability()
-    frame = result.set_frame(DiagnosticArray(status=[status]))
-    assert result.success is False
-    assert result.summary == "Yabloc Availability (Fail): NG"
-    assert frame == {
+    evaluation_item = Availability()
+    frame_dict = evaluation_item.set_frame(DiagnosticArray(status=[status]))
+    assert evaluation_item.success is False
+    assert evaluation_item.summary == "Yabloc Availability (Fail): NG"
+    assert frame_dict == {
         "Ego": {},
         "Availability": {
             "Result": {"Total": "Fail", "Frame": "Fail"},
@@ -60,11 +60,11 @@ def test_availability_fail_key_not_found() -> None:
         name=Availability.TARGET_DIAG_NAME,
         values=[KeyValue(key="Convergence", value="AnyValue")],
     )
-    result = Availability()
-    frame = result.set_frame(DiagnosticArray(status=[status]))
-    assert result.success is False
-    assert result.summary == "Yabloc Availability (Fail): Availability Key Not Found"
-    assert frame == {
+    evaluation_item = Availability()
+    frame_dict = evaluation_item.set_frame(DiagnosticArray(status=[status]))
+    assert evaluation_item.success is False
+    assert evaluation_item.summary == "Yabloc Availability (Fail): Availability Key Not Found"
+    assert frame_dict == {
         "Ego": {},
         "Availability": {
             "Result": {"Total": "Fail", "Frame": "Fail"},
@@ -75,11 +75,11 @@ def test_availability_fail_key_not_found() -> None:
 
 def test_availability_has_no_target_diag() -> None:
     status = DiagnosticStatus(name="not_yabloc_status")
-    result = Availability()
-    frame = result.set_frame(DiagnosticArray(status=[status]))
-    assert result.success is False  # default value is False
-    assert result.summary == "NotTested"
-    assert frame == {
+    evaluation_item = Availability()
+    frame_dict = evaluation_item.set_frame(DiagnosticArray(status=[status]))
+    assert evaluation_item.success is False  # default value is False
+    assert evaluation_item.summary == "NotTested"
+    assert frame_dict == {
         "Ego": {},
         "Availability": {
             "Result": {"Total": "Fail", "Frame": "Warn"},

--- a/driving_log_replayer/test/unittest/test_yabloc.py
+++ b/driving_log_replayer/test/unittest/test_yabloc.py
@@ -16,15 +16,15 @@ from diagnostic_msgs.msg import DiagnosticArray
 from diagnostic_msgs.msg import DiagnosticStatus
 from diagnostic_msgs.msg import KeyValue
 
-from driving_log_replayer.yabloc import AvailabilityResult
+from driving_log_replayer.yabloc import Availability
 
 
 def test_availability_success() -> None:
     status = DiagnosticStatus(
-        name=AvailabilityResult.TARGET_DIAG_NAME,
+        name=Availability.TARGET_DIAG_NAME,
         values=[KeyValue(key="Availability", value="OK")],
     )
-    result = AvailabilityResult()
+    result = Availability()
     frame = result.set_frame(DiagnosticArray(status=[status]))
     assert result.success is True
     assert result.summary == "Yabloc Availability (Success): OK"
@@ -39,10 +39,10 @@ def test_availability_success() -> None:
 
 def test_availability_fail() -> None:
     status = DiagnosticStatus(
-        name=AvailabilityResult.TARGET_DIAG_NAME,
+        name=Availability.TARGET_DIAG_NAME,
         values=[KeyValue(key="Availability", value="NG")],
     )
-    result = AvailabilityResult()
+    result = Availability()
     frame = result.set_frame(DiagnosticArray(status=[status]))
     assert result.success is False
     assert result.summary == "Yabloc Availability (Fail): NG"
@@ -57,10 +57,10 @@ def test_availability_fail() -> None:
 
 def test_availability_fail_key_not_found() -> None:
     status = DiagnosticStatus(
-        name=AvailabilityResult.TARGET_DIAG_NAME,
+        name=Availability.TARGET_DIAG_NAME,
         values=[KeyValue(key="Convergence", value="AnyValue")],
     )
-    result = AvailabilityResult()
+    result = Availability()
     frame = result.set_frame(DiagnosticArray(status=[status]))
     assert result.success is False
     assert result.summary == "Yabloc Availability (Fail): Availability Key Not Found"
@@ -75,7 +75,7 @@ def test_availability_fail_key_not_found() -> None:
 
 def test_availability_has_no_target_diag() -> None:
     status = DiagnosticStatus(name="not_yabloc_status")
-    result = AvailabilityResult()
+    result = Availability()
     frame = result.set_frame(DiagnosticArray(status=[status]))
     assert result.success is False  # default value is False
     assert result.summary == "NotTested"


### PR DESCRIPTION
## Types of PR

- [x] New Features

## Description

- add unit test

To add test code for quality control of driving_log_replayer

The driving_log_replayer is a tool that operates as follows:

1. It subscribes to topics published by Autoware.
2. It determines success or failure based on the subscribed topic meeting certain conditions and writes the results to result.jsonl.

Therefore, add unit tests for the process of writing messages received from Autoware.

1. Prepare a message for success and a message for failure.
2. Test whether the Result class can correctly determine success and failure by passing messages to it.

## How to review this PR

Thanks to colcon test, unit tests are now automatically executed. Therefore, please verify the following:

1. Ensure that all checks in GitHub Actions have passed.
2. Verify that the contents of test_yabloc.py are correctly coded.

## Others
