### PR TITLE
fix(perception): remove `typing_extensions`

### DIFF
--- a/driving_log_replayer/driving_log_replayer/criteria/perception.py
+++ b/driving_log_replayer/driving_log_replayer/criteria/perception.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 
+from __future__ import annotations
+
 from abc import ABC
 from abc import abstractmethod
 from enum import Enum
@@ -21,7 +23,6 @@ from numbers import Number
 from perception_eval.common.evaluation_task import EvaluationTask
 from perception_eval.evaluation import PerceptionFrameResult
 from perception_eval.evaluation.matching import MatchingMode
-from typing_extensions import Self
 
 
 class SuccessFail(Enum):
@@ -78,7 +79,7 @@ class CriteriaLevel(Enum):
         return score >= self.value
 
     @classmethod
-    def from_str(cls, value: str) -> Self:
+    def from_str(cls, value: str) -> CriteriaLevel:
         """
         Construct instance from.
 
@@ -96,7 +97,7 @@ class CriteriaLevel(Enum):
         return cls.__members__[name]
 
     @classmethod
-    def from_number(cls, value: Number) -> Self:
+    def from_number(cls, value: Number) -> CriteriaLevel:
         """
         Construct `CriteriaLevel.CUSTOM` with custom value.
 
@@ -129,7 +130,7 @@ class CriteriaMethod(Enum):
     METRICS_SCORE = "metrics_score"
 
     @classmethod
-    def from_str(cls, value: str) -> Self:
+    def from_str(cls, value: str) -> CriteriaMethod:
         """
         Construct instance from name in string.
 


### PR DESCRIPTION
## Types of PR

- [x] Bugfix

## Description
This PR removes `typing_extensions` because it can't be imported in WebAuto, like following log

```shell
[perception_evaluator_node.py-71] Traceback (most recent call last):
[perception_evaluator_node.py-71]   File "/home/autoware/autoware.proj/install/driving_log_replayer/lib/driving_log_replayer/perception_evaluator_node.py", line 44, in <module>
[perception_evaluator_node.py-71]     from driving_log_replayer.criteria import PerceptionCriteria
[perception_evaluator_node.py-71]   File "/home/autoware/autoware.proj/install/driving_log_replayer/local/lib/python3.10/dist-packages/driving_log_replayer/criteria/__init__.py", line 15, in <module>
[perception_evaluator_node.py-71]     from .perception import CriteriaLevel
[perception_evaluator_node.py-71]   File "/home/autoware/autoware.proj/install/driving_log_replayer/local/lib/python3.10/dist-packages/driving_log_replayer/criteria/perception.py", line 24, in <module>
[perception_evaluator_node.py-71]     from typing_extensions import Self
[perception_evaluator_node.py-71] ModuleNotFoundError: No module named 'typing_extensions'
```

@hayato-m126 Actually, we have two options 
- 1. remove `typing_extensions`
- 2. add `python3-typing-extensions` to package.xml, note that it can be insatalled with [rosdep](https://github.com/ros/rosdistro/blob/cafc610c150e8b2d2386930a85bb9fac2c459095/rosdep/python.yaml#L9174-L9179)

## How to review this PR

## Others
