### PR TITLE
feat(perception): allow to specify perception mode in scenario

### DIFF
--- a/driving_log_replayer/driving_log_replayer/launch_common.py
+++ b/driving_log_replayer/driving_log_replayer/launch_common.py
@@ -83,6 +83,7 @@ def get_driving_log_replayer_common_argument() -> list:
     add_launch_arg("vehicle_id", default_value="default", description="vehicle specific ID")
 
     # additional argument
+    add_launch_arg("perception_mode", default_value="lidar", description="perception mode")
     add_launch_arg(
         "t4_dataset_path",
         default_value="/opt/autoware/t4_dataset",
@@ -105,7 +106,6 @@ def get_autoware_launch(
     planning: str = "false",
     control: str = "false",
     scenario_simulation: str = "false",
-    perception_mode: str = "lidar",
     pose_source: str = "ndt",
     twist_source: str = "gyro_odom",
 ) -> launch.actions.IncludeLaunchDescription:
@@ -129,7 +129,7 @@ def get_autoware_launch(
             "planning": planning,
             "control": control,
             "scenario_simulation": scenario_simulation,
-            "perception_mode": perception_mode,
+            "perception_mode": LaunchConfiguration("perception_mode"),
             "pose_source": pose_source,
             "twist_source": twist_source,
             "rviz": "false",

--- a/driving_log_replayer_cli/simulation/generate.py
+++ b/driving_log_replayer_cli/simulation/generate.py
@@ -198,7 +198,7 @@ class TestScriptGenerator:
         print("launch command generated! => " + launch_command)  # noqa
         return launch_command
 
-    def __create_launch_command_with_t4_dataset(
+    def __create_launch_command_with_t4_dataset(  # noqa TODO: fix logic
         self,
         scenario_root: str,
         scenario_name: str,

--- a/driving_log_replayer_cli/simulation/generate.py
+++ b/driving_log_replayer_cli/simulation/generate.py
@@ -1,14 +1,22 @@
 import glob
 import os
-import subprocess
 from pathlib import Path
+import subprocess
 
+from natsort import natsorted
 import termcolor
 import yaml
-from natsort import natsorted
 
 
 class TestScriptGenerator:
+    PERCEPTION_MODES = (
+        "camera_lidar_radar_fusion",
+        "camera_lidar_fusion",
+        "lidar_radar_fusion",
+        "lidar",
+        "radar",
+    )
+
     def __init__(
         self,
         data_directory: str,
@@ -265,15 +273,8 @@ class TestScriptGenerator:
             launch_args += " rviz:=true"
             if scenario_yaml_obj.get("PerceptionMode") is not None:
                 perception_mode: str = scenario_yaml_obj["PerceptionMode"]
-                valid_modes = (
-                    "camera_lidar_radar_fusion",
-                    "camera_lidar_fusion",
-                    "lidar_radar_fusion",
-                    "lidar",
-                    "radar",
-                )
-                assert perception_mode in valid_modes, (
-                    f"perception_mode must be chosen from {valid_modes}, "
+                assert perception_mode in self.PERCEPTION_MODES, (
+                    f"perception_mode must be chosen from {self.PERCEPTION_MODES}, "
                     f"but got {perception_mode}"
                 )
                 launch_args += " perception_mode:=" + perception_mode

--- a/driving_log_replayer_cli/simulation/generate.py
+++ b/driving_log_replayer_cli/simulation/generate.py
@@ -1,11 +1,11 @@
 import glob
 import os
-from pathlib import Path
 import subprocess
+from pathlib import Path
 
-from natsort import natsorted
 import termcolor
 import yaml
+from natsort import natsorted
 
 
 class TestScriptGenerator:
@@ -263,6 +263,8 @@ class TestScriptGenerator:
             launch_args += " sensor_model:=" + scenario_yaml_obj["SensorModel"]
             launch_args += " vehicle_id:=" + vehicle_id
             launch_args += " rviz:=true"
+            if scenario_yaml_obj.get("PerceptionMode") is not None:
+                launch_args += " perception_mode:=" + scenario_yaml_obj["PerceptionMode"]
 
             # t4_dataset
             launch_args += " t4_dataset_path:=" + t4_dataset_path

--- a/driving_log_replayer_cli/simulation/generate.py
+++ b/driving_log_replayer_cli/simulation/generate.py
@@ -264,7 +264,19 @@ class TestScriptGenerator:
             launch_args += " vehicle_id:=" + vehicle_id
             launch_args += " rviz:=true"
             if scenario_yaml_obj.get("PerceptionMode") is not None:
-                launch_args += " perception_mode:=" + scenario_yaml_obj["PerceptionMode"]
+                perception_mode: str = scenario_yaml_obj["PerceptionMode"]
+                valid_modes = (
+                    "camera_lidar_radar_fusion",
+                    "camera_lidar_fusion",
+                    "lidar_radar_fusion",
+                    "lidar",
+                    "radar",
+                )
+                assert perception_mode in valid_modes, (
+                    f"perception_mode must be chosen from {valid_modes}, "
+                    f"but got {perception_mode}"
+                )
+                launch_args += " perception_mode:=" + perception_mode
 
             # t4_dataset
             launch_args += " t4_dataset_path:=" + t4_dataset_path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "driving_log_replayer_cli"
-version = "1.6.7"
+version = "1.7.0"
 description = "command line tool for driving_log_replayer"
 authors = [
   "Hayato Mizushima <hayato.mizushima@tier4.jp>",

--- a/sample/perception/scenario.fp.ja.yaml
+++ b/sample/perception/scenario.fp.ja.yaml
@@ -1,4 +1,4 @@
-ScenarioFormatVersion: 3.0.0
+ScenarioFormatVersion: 3.1.0
 ScenarioName: fp_sample
 ScenarioDescription: fp_sample
 SensorModel: sample_sensor_kit

--- a/sample/perception/scenario.fp.ja.yaml
+++ b/sample/perception/scenario.fp.ja.yaml
@@ -3,6 +3,7 @@ ScenarioName: fp_sample
 ScenarioDescription: fp_sample
 SensorModel: sample_sensor_kit
 VehicleModel: sample_vehicle
+PerceptionMode: lidar
 Evaluation:
   UseCaseName: perception
   UseCaseFormatVersion: 0.6.0

--- a/sample/perception/scenario.fp.yaml
+++ b/sample/perception/scenario.fp.yaml
@@ -1,4 +1,4 @@
-ScenarioFormatVersion: 3.0.0
+ScenarioFormatVersion: 3.1.0
 ScenarioName: fp_sample
 ScenarioDescription: fp_sample
 SensorModel: sample_sensor_kit

--- a/sample/perception/scenario.fp.yaml
+++ b/sample/perception/scenario.fp.yaml
@@ -3,6 +3,7 @@ ScenarioName: fp_sample
 ScenarioDescription: fp_sample
 SensorModel: sample_sensor_kit
 VehicleModel: sample_vehicle
+PerceptionMode: lidar
 Evaluation:
   UseCaseName: perception
   UseCaseFormatVersion: 0.6.0

--- a/sample/perception/scenario.ja.yaml
+++ b/sample/perception/scenario.ja.yaml
@@ -1,4 +1,4 @@
-ScenarioFormatVersion: 3.0.0
+ScenarioFormatVersion: 3.1.0
 ScenarioName: perception_use_bag_concat_data
 ScenarioDescription: sensing_module_off_and_use_pointcloud_in_the_rosbag
 SensorModel: sample_sensor_kit

--- a/sample/perception/scenario.ja.yaml
+++ b/sample/perception/scenario.ja.yaml
@@ -3,6 +3,7 @@ ScenarioName: perception_use_bag_concat_data
 ScenarioDescription: sensing_module_off_and_use_pointcloud_in_the_rosbag
 SensorModel: sample_sensor_kit
 VehicleModel: sample_vehicle
+PerceptionMode: lidar
 Evaluation:
   UseCaseName: perception
   UseCaseFormatVersion: 0.6.0

--- a/sample/perception/scenario.yaml
+++ b/sample/perception/scenario.yaml
@@ -1,4 +1,4 @@
-ScenarioFormatVersion: 3.0.0
+ScenarioFormatVersion: 3.1.0
 ScenarioName: perception_use_bag_concat_data
 ScenarioDescription: sensing_module_off_and_use_pointcloud_in_the_rosbag
 SensorModel: sample_sensor_kit

--- a/sample/perception/scenario.yaml
+++ b/sample/perception/scenario.yaml
@@ -3,6 +3,7 @@ ScenarioName: perception_use_bag_concat_data
 ScenarioDescription: sensing_module_off_and_use_pointcloud_in_the_rosbag
 SensorModel: sample_sensor_kit
 VehicleModel: sample_vehicle
+PerceptionMode: lidar
 Evaluation:
   UseCaseName: perception
   UseCaseFormatVersion: 0.6.0

--- a/sample/perception_2d/scenario.ja.yaml
+++ b/sample/perception_2d/scenario.ja.yaml
@@ -3,6 +3,7 @@ ScenarioName: perception_2d_x2
 ScenarioDescription: perception_2d_x2
 SensorModel: aip_x2
 VehicleModel: gsm8
+PerceptionMode: camera_lidar_fusion
 Evaluation:
   UseCaseName: perception_2d
   UseCaseFormatVersion: 0.3.0

--- a/sample/perception_2d/scenario.ja.yaml
+++ b/sample/perception_2d/scenario.ja.yaml
@@ -1,4 +1,4 @@
-ScenarioFormatVersion: 3.0.0
+ScenarioFormatVersion: 3.1.0
 ScenarioName: perception_2d_x2
 ScenarioDescription: perception_2d_x2
 SensorModel: aip_x2

--- a/sample/perception_2d/scenario.yaml
+++ b/sample/perception_2d/scenario.yaml
@@ -3,6 +3,7 @@ ScenarioName: perception_2d_x2
 ScenarioDescription: perception_2d_x2
 SensorModel: aip_x2
 VehicleModel: gsm8
+PerceptionMode: camera_lidar_fusion
 Evaluation:
   UseCaseName: perception_2d
   UseCaseFormatVersion: 0.3.0

--- a/sample/perception_2d/scenario.yaml
+++ b/sample/perception_2d/scenario.yaml
@@ -1,4 +1,4 @@
-ScenarioFormatVersion: 3.0.0
+ScenarioFormatVersion: 3.1.0
 ScenarioName: perception_2d_x2
 ScenarioDescription: perception_2d_x2
 SensorModel: aip_x2


### PR DESCRIPTION
## Types of PR

- [x] New Features

## Description
Update to enable specifying `perception_mode` in scenario file.
If not specified, default `perception_mode` specified in `autoware_launch` is used.

```yaml
ScenarioFormatVersion: 3.0.0
ScenarioName: sample_scenario
ScenarioDescription: sample scenario
SensorModel: sample_sensor_kit
VehicleModel: lexus
PerceptionMode: camera_lidar_fusion # ("camera_lidar_radar_fusion", "camera_lidar_fusion", "lidar_radar_fusion", "lidar","radar")
Evaluation:
...
```

## How to review this PR

## Others
