### PR TITLE
perf: fixed to use `/localization/pose_estimator/initial_to_result_relative_pose`

### DIFF
--- a/docs/use_case/localization.en.md
+++ b/docs/use_case/localization.en.md
@@ -182,8 +182,8 @@ Convergence Result example:
   "Convergence": {
     "Result": "Success or Fail",
     "Info": {
-      "LateralDistance": "Lateral distance between ndt and ekf pose",
-      "HorizontalDistance": "Horizontal distance between ndt and ekf. Reference value",
+      "LateralDistance": "initial_to_result_relative_pose.pose.position.y",
+      "HorizontalDistance": "Horizontal distance of initial_to_result_relative_pose.pose.position",
       "ExeTimeMs": "Time taken to calculate ndt",
       "IterationNum": "Number of recalculations of ndt"
     }

--- a/docs/use_case/localization.en.md
+++ b/docs/use_case/localization.en.md
@@ -1,8 +1,8 @@
-# Evaluate self-localization estimation
+# Evaluate self-localization estimation (NDT)
 
-Evaluate whether Autoware's localization is working stably.
+Evaluate whether Autoware's localization by NDT is working stably.
 
-In the evaluation of localization, the reliability and convergence of NDT are evaluated.
+In the evaluation of localization, the reliability, convergence, and availability of NDT are evaluated.
 
 ## Evaluation method
 
@@ -25,8 +25,7 @@ Of the following two topics, the one specified in the scenario will be used for 
 
 Convergence evaluation is based on the following topics:
 
-- `/localization/pose_estimator/pose`
-- `/localization/pose_twist_fusion_filter/pose`
+- `/localization/pose_estimator/initial_to_result_relative_pose`
 
 ### Availability of NDT
 
@@ -62,11 +61,11 @@ If the data in `/localization/pose_estimator/transform_probability` or `/localiz
 
 If all of the following conditions are met, the convergence is reported as Normal:
 
-1. The lateral distance (calculated from `/localization/pose_estimator/pose` and `/localization/pose_twist_fusion_filter/pose` topics output) is less than or equal to `AllowableDistance` described in the scenario
+1. The lateral distance (`y` value of `/localization/pose_estimator/initial_to_result_relative_pose`) is less than or equal to `AllowableDistance` described in the scenario
 2. Execution time published to `/localization/pose_estimator/exe_time_ms` is less than or equal to `AllowableExeTimeMs` described in the scenario
 3. Number of iterations published to `/localization/pose_estimator/iteration_num` is less than or equal to `AllowableIterationNum` described in the scenario
 
-The lateral distance calculated in the step 1 is published as `/driving_log_replayer/localization/lateral_distance`.
+The lateral distance obtained in the step 1 is published as `/driving_log_replayer/localization/lateral_distance`.
 
 ### Convergence Error
 
@@ -89,8 +88,7 @@ Subscribed topics:
 | /diagnostics_agg                                                     | diagnostic_msgs::msg::DiagnosticArray |
 | /localization/pose_estimator/transform_probability                   | tier4_debug_msgs::msg::Float32Stamped |
 | /localization/pose_estimator/nearest_voxel_transformation_likelihood | tier4_debug_msgs::msg::Float32Stamped |
-| /localization/pose_estimator/pose                                    | geometry_msgs::msg::PoseStamped       |
-| /localization/kinematic_state                                        | nav_msgs::msg::Odometry               |
+| /localization/pose_estimator/initial_to_result_relative_pose         | geometry_msgs::msg::PoseStamped       |
 | /localization/pose_estimator/exe_time_ms                             | tier4_debug_msgs::msg::Float32Stamped |
 | /localization/pose_estimator/iteration_num                           | tier4_debug_msgs::msg::Int32Stamped   |
 | /tf                                                                  | tf2_msgs/msg/TFMessage                |

--- a/docs/use_case/localization.en.md
+++ b/docs/use_case/localization.en.md
@@ -61,7 +61,7 @@ If the data in `/localization/pose_estimator/transform_probability` or `/localiz
 
 If all of the following conditions are met, the convergence is reported as Normal:
 
-1. The lateral distance (`y` value of `/localization/pose_estimator/initial_to_result_relative_pose`) is less than or equal to `AllowableDistance` described in the scenario
+1. The lateral distance of `/localization/pose_estimator/initial_to_result_relative_pose` is less than or equal to `AllowableDistance` described in the scenario
 2. Execution time published to `/localization/pose_estimator/exe_time_ms` is less than or equal to `AllowableExeTimeMs` described in the scenario
 3. Number of iterations published to `/localization/pose_estimator/iteration_num` is less than or equal to `AllowableIterationNum` described in the scenario
 

--- a/docs/use_case/localization.ja.md
+++ b/docs/use_case/localization.ja.md
@@ -183,8 +183,8 @@ Result は収束性、信頼度、可用性のすべてをパスしていれば 
   "Convergence": {
     "Result": { "Total": "Success or Fail", "Frame": "Success or Fail" },
     "Info": {
-      "LateralDistance": "ndtとekfのposeの横方距離",
-      "HorizontalDistance": "ndtとekfの水平距離。参考値",
+      "LateralDistance": "initial_to_result_relative_pose.pose.position.y",
+      "HorizontalDistance": "initial_to_result_relative_pose.pose.positionの水平距離。参考値",
       "ExeTimeMs": "ndtの計算にかかった時間",
       "IterationNum": "ndtの再計算回数"
     }

--- a/docs/use_case/localization.ja.md
+++ b/docs/use_case/localization.ja.md
@@ -1,8 +1,8 @@
-# 自己位置推定の評価
+# 自己位置推定(NDT)の評価
 
-Autoware の自己位置推定(localization)が安定して動作しているかを評価する。
+NDTによるAutowareの自己位置推定が安定して動作しているかを評価する。
 
-自己位置推定の評価では NDT の信頼度と収束性を評価する。
+自己位置推定の評価では NDT の信頼度、収束性、可用性を評価する。
 
 ## 評価方法
 
@@ -25,8 +25,7 @@ launch を立ち上げると以下のことが実行され、評価される。
 
 以下を用いて評価する
 
-- /localization/pose_estimator/pose
-- /localization/pose_twist_fusion_filter/pose
+- /localization/pose_estimator/initial_to_result_relative_pose
 
 ### NDT の可用性
 
@@ -61,11 +60,11 @@ topic の subscribe 1 回につき、以下に記述する判定結果が出力�
 
 以下の 3 つの条件を全て満たす場合
 
-1. /localization/pose_estimator/pose と /localization/pose_twist_fusion_filter/pose から横方向の距離を計算して、シナリオに記述した AllowableDistance 以下
+1. /localization/pose_estimator/initial_to_result_relative_poseの横方向距離が、シナリオに記述した AllowableDistance 以下
 2. /localization/pose_estimator/exe_time_ms が、シナリオに記述した AllowableExeTimeMs 以下
 3. /localization/pose_estimator/iteration_num が、シナリオに記述した AllowableIterationNum 以下
 
-ステップ 1 で計算した横方向の距離が/driving_log_replayer/localization/lateral_distance として publish される。
+ステップ 1 で取得した横方向距離が/driving_log_replayer/localization/lateral_distance として publish される。
 
 ### 収束異常
 
@@ -89,8 +88,7 @@ Subscribed topics:
 | /diagnostics_agg                                                     | diagnostic_msgs::msg::DiagnosticArray |
 | /localization/pose_estimator/transform_probability                   | tier4_debug_msgs::msg::Float32Stamped |
 | /localization/pose_estimator/nearest_voxel_transformation_likelihood | tier4_debug_msgs::msg::Float32Stamped |
-| /localization/pose_estimator/pose                                    | geometry_msgs::msg::PoseStamped       |
-| /localization/kinematic_state                                        | nav_msgs::msg::Odometry               |
+| /localization/pose_estimator/initial_to_result_relative_pose         | geometry_msgs::msg::PoseStamped       |
 | /localization/pose_estimator/exe_time_ms                             | tier4_debug_msgs::msg::Float32Stamped |
 | /localization/pose_estimator/iteration_num                           | tier4_debug_msgs::msg::Int32Stamped   |
 | /tf                                                                  | tf2_msgs/msg/TFMessage                |

--- a/driving_log_replayer/driving_log_replayer/localization.py
+++ b/driving_log_replayer/driving_log_replayer/localization.py
@@ -21,10 +21,8 @@ from typing import ClassVar
 from diagnostic_msgs.msg import DiagnosticArray
 from example_interfaces.msg import Float64
 from geometry_msgs.msg import PoseStamped
-from nav_msgs.msg import Odometry
 import numpy as np
 from rosidl_runtime_py import message_to_ordereddict
-from tf_transformations import euler_from_quaternion
 from tier4_debug_msgs.msg import Float32Stamped
 from tier4_debug_msgs.msg import Int32Stamped
 

--- a/driving_log_replayer/driving_log_replayer/localization.py
+++ b/driving_log_replayer/driving_log_replayer/localization.py
@@ -32,30 +32,14 @@ from driving_log_replayer.result import EvaluationItem
 from driving_log_replayer.result import ResultBase
 
 
-def calc_pose_lateral_distance(ndt_pose: PoseStamped, ekf_pose: Odometry) -> float:
-    base_point = ndt_pose.pose.position
-    _, _, yaw = euler_from_quaternion(
-        [
-            ndt_pose.pose.orientation.x,
-            ndt_pose.pose.orientation.y,
-            ndt_pose.pose.orientation.z,
-            ndt_pose.pose.orientation.w,
-        ],
-    )
-    base_unit_vec = np.array([np.cos(yaw), np.sin(yaw), 0.0])
-    dx = ekf_pose.pose.pose.position.x - base_point.x
-    dy = ekf_pose.pose.pose.position.y - base_point.y
-    diff_vec = np.array([dx, dy, 0.0])
-    cross_vec = np.cross(base_unit_vec, diff_vec)
-    return cross_vec[2]
+def calc_pose_lateral_distance(relative_pose: PoseStamped) -> float:
+    return relative_pose.pose.position.y
 
 
-def calc_pose_horizontal_distance(ndt_pose: PoseStamped, ekf_pose: Odometry) -> float:
-    ndt_x = ndt_pose.pose.position.x
-    ndt_y = ndt_pose.pose.position.y
-    ekf_x = ekf_pose.pose.pose.position.x
-    ekf_y = ekf_pose.pose.pose.position.y
-    return np.sqrt(np.power(ndt_x - ekf_x, 2) + np.power(ndt_y - ekf_y, 2))
+def calc_pose_horizontal_distance(relative_pose: PoseStamped) -> float:
+    x = relative_pose.pose.position.x
+    y = relative_pose.pose.position.y
+    return np.sqrt(np.power(x, 2) + np.power(y, 2))
 
 
 def get_reliability_method(method_name: str | None) -> tuple[str | None, str]:

--- a/driving_log_replayer/scripts/localization_evaluator_node.py
+++ b/driving_log_replayer/scripts/localization_evaluator_node.py
@@ -36,7 +36,6 @@ class LocalizationEvaluator(DLREvaluator):
         self.check_scenario()
         self.__result = LocalizationResult(self._condition)
 
-        self.__latest_ekf_pose: Odometry = Odometry()
         self.__latest_exe_time: Float32Stamped = Float32Stamped()
         self.__latest_iteration_num: Int32Stamped = Int32Stamped()
         self.__latest_tp: Float32Stamped = Float32Stamped()
@@ -59,16 +58,10 @@ class LocalizationEvaluator(DLREvaluator):
             self.nvtl_cb,
             1,
         )
-        self.__sub_pose = self.create_subscription(
+        self.__sub_relative_pose = self.create_subscription(
             PoseStamped,
-            "/localization/pose_estimator/pose",
-            self.pose_cb,
-            1,
-        )
-        self.__sub_ekf_pose = self.create_subscription(
-            Odometry,
-            "/localization/kinematic_state",
-            self.ekf_pose_cb,
+            "/localization/pose_estimator/initial_to_result_relative_pose",
+            self.relative_pose_cb,
             1,
         )
         self.__sub_exe_time = self.create_subscription(
@@ -97,9 +90,6 @@ class LocalizationEvaluator(DLREvaluator):
         if self.__reliability_method is None:
             self.get_logger().error(error_msg)
             rclpy.shutdown()
-
-    def ekf_pose_cb(self, msg: Odometry) -> None:
-        self.__latest_ekf_pose = msg
 
     def exe_time_cb(self, msg: Float32Stamped) -> None:
         self.__latest_exe_time = msg
@@ -133,11 +123,11 @@ class LocalizationEvaluator(DLREvaluator):
         )
         self._result_writer.write_result(self.__result)
 
-    def pose_cb(self, msg: PoseStamped) -> None:
+    def relative_pose_cb(self, msg: PoseStamped) -> None:
         map_to_baselink = self.lookup_transform(msg.header.stamp)
         msg_lateral_distance = self.__result.set_frame(
-            calc_pose_lateral_distance(msg, self.__latest_ekf_pose),
-            calc_pose_horizontal_distance(msg, self.__latest_ekf_pose),
+            calc_pose_lateral_distance(msg),
+            calc_pose_horizontal_distance(msg),
             DLREvaluator.transform_stamped_with_euler_angle(map_to_baselink),
             self.__latest_exe_time,
             self.__latest_iteration_num,

--- a/driving_log_replayer/scripts/localization_evaluator_node.py
+++ b/driving_log_replayer/scripts/localization_evaluator_node.py
@@ -17,7 +17,6 @@
 from diagnostic_msgs.msg import DiagnosticArray
 from example_interfaces.msg import Float64
 from geometry_msgs.msg import PoseStamped
-from nav_msgs.msg import Odometry
 import rclpy
 from tier4_debug_msgs.msg import Float32Stamped
 from tier4_debug_msgs.msg import Int32Stamped


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [x] Upgrade of existing features
- [ ] Bugfix

## Description
In the latest awf:autoware_universe, the output of relative Pose fixed by NDT has been added as an output topic for NDT.

https://github.com/autowarefoundation/autoware.universe/pull/5319

The topic name is `/localizaiton/pose_estimator/initial_to_result_relative_pose`.

Before the change, DiviringLogReplayer subscribed to the EKF Pose and compared the latest EKF Pose with the NDT Pose, causing some problems with time synchronization. 
(If the NDT takes about 100 msec to process, there will be a difference of about 100 msec between the timestamp that the sensor, which is the input to the NDT, has and the timestamp after the NDT processing.)

I would like to change this as the new indicator is more appropriate.

## Result
I plotted `Lateral Distance` and `Horizontal Distance` for the json obtained by running localization mode.

|Before|After|
|:--------:|:----:|
![distance](https://github.com/tier4/driving_log_replayer/assets/28504069/4a17dad6-996f-4212-8f0e-230a72308609)|![distance](https://github.com/tier4/driving_log_replayer/assets/28504069/ecaddae9-e1c5-4549-95cf-03ecd1c8692b)|

The two main differences are as follows.

* The sign of Lateral Distance is reversed from the previous one.
* Overall, the error is smaller. As mentioned above, this is believed to be due to the elimination of time synchronization errors.

## How to review this PR
Please confirm that the localization mode is working properly.
