### PR TITLE
feat: parameterize perception mode

### DIFF
--- a/docs/scenario_format/index.en.md
+++ b/docs/scenario_format/index.en.md
@@ -94,10 +94,6 @@ Specify `vehicle_id` as an argument in `autoware_launch/launch/logging_simulator
 
 If you don't know `vehicle_id`, set `default`.
 
-### PerceptionMode
-
-Specify the `perception_mode` in `autoware_launch/launch/autoware.launch.xml`.
-
 ### LocalMapPath
 
 Describes the path of the map folder to be used in the local environment.

--- a/docs/scenario_format/index.en.md
+++ b/docs/scenario_format/index.en.md
@@ -53,7 +53,6 @@ ScenarioName: String
 ScenarioDescription: String
 SensorModel: String
 VehicleModel: String
-PerceptionMode: String
 Evaluation:
   UseCaseName: String
   UseCaseFormatVersion: String
@@ -69,7 +68,7 @@ Evaluation:
 Describe the version information of the scenario format. Use the semantic version.
 
 `localization`, `performance_diag`, `yabloc`, `eagleye` and `ar_tag_based_localizer` scenarios use the 2.x.x series. The latest version of 2.x.x is 2.2.0.
-`perception` and `obstacle_segmentation` scenarios use 3.x.x series. The latest version of 3.x.x is 3.1 .0
+`perception` and `obstacle_segmentation` scenarios use 3.x.x series. The latest version of 3.x.x is 3.0.0
 
 Minor versions are updated each time the format is updated.
 

--- a/docs/scenario_format/index.ja.md
+++ b/docs/scenario_format/index.ja.md
@@ -53,7 +53,6 @@ ScenarioName: String
 ScenarioDescription: String
 SensorModel: String
 VehicleModel: String
-PerceptionMode: String
 Evaluation:
   UseCaseName: String
   UseCaseFormatVersion: String
@@ -69,7 +68,7 @@ Evaluation:
 シナリオフォーマットのバージョン情報を記述する。セマンティックバージョンを用いる。
 
 `localization` と `performance_diag` と `yabloc` と `eagleye` と `ar_tag_based_localizer` は 2.x.x 系を使用する。2.x.x の最新バージョンは 2.2.0
-`perception` と `obstacle_segmentation` は 3.x.x 系を使用する。3.x.x の最新バージョンは 3.1.0
+`perception` と `obstacle_segmentation` は 3.x.x 系を使用する。3.x.x の最新バージョンは 3.0.0
 
 フォーマットの更新の度にマイナーバージョンを更新する。
 

--- a/docs/scenario_format/index.ja.md
+++ b/docs/scenario_format/index.ja.md
@@ -94,10 +94,6 @@ autoware_launch/launch/logging_simulator.launch.xml の引数の vehicle_id を�
 
 車両 ID が不明な場合は、`default` を設定する。
 
-### PerceptionMode
-
-autoware_launch/launch/autoware.launch.xml の perception_mode を指定する。
-
 ### LocalMapPath
 
 ローカル環境で使用する地図のフォルダのパスを記述する。

--- a/driving_log_replayer_cli/simulation/__init__.py
+++ b/driving_log_replayer_cli/simulation/__init__.py
@@ -6,9 +6,16 @@ import click
 from driving_log_replayer_cli.core.config import load_config
 from driving_log_replayer_cli.simulation.result import convert
 from driving_log_replayer_cli.simulation.result import display
-from driving_log_replayer_cli.simulation.run import run as sim_run
+from driving_log_replayer_cli.simulation.run import DrivingLogReplayerTestRunner
 
 CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
+PERCEPTION_MODES = (
+    "camera_lidar_radar_fusion",
+    "camera_lidar_fusion",
+    "lidar_radar_fusion",
+    "lidar",
+    "radar",
+)
 
 
 @click.group(context_settings=CONTEXT_SETTINGS)
@@ -21,20 +28,33 @@ def simulation() -> None:
 @click.option("--rate", "-r", default=1.0)
 @click.option("--delay", "-d", default=10.0)
 @click.option("--no-json", is_flag=True, help="Do not convert jsonl files to json")
-def run(profile: str, rate: float, delay: float, no_json: bool) -> None:  # noqa
+@click.option(
+    "--perception-mode",
+    "-m",
+    default="lidar",
+    type=click.Choice(PERCEPTION_MODES, case_sensitive=False),
+)
+def run(
+    profile: str,
+    rate: float,
+    delay: float,
+    no_json: bool,  # noqa
+    perception_mode: str,
+) -> None:
     config = load_config(profile)
     output_dir_by_time = Path(
         config.output_directory,
         datetime.datetime.now().strftime("%Y-%m%d-%H%M%S"),  # noqa
     )
     print(output_dir_by_time)  # noqa
-    sim_run(
+    DrivingLogReplayerTestRunner(
         config.data_directory,
         output_dir_by_time.as_posix(),
         config.autoware_path,
         rate,
         delay,
         not no_json,
+        perception_mode,
     )
 
 

--- a/driving_log_replayer_cli/simulation/__init__.py
+++ b/driving_log_replayer_cli/simulation/__init__.py
@@ -27,13 +27,13 @@ def simulation() -> None:
 @click.option("--profile", "-p", type=str, default="default")
 @click.option("--rate", "-r", default=1.0)
 @click.option("--delay", "-d", default=10.0)
-@click.option("--no-json", is_flag=True, help="Do not convert jsonl files to json")
 @click.option(
     "--perception-mode",
     "-m",
     default="lidar",
     type=click.Choice(PERCEPTION_MODES, case_sensitive=False),
 )
+@click.option("--no-json", is_flag=True, help="Do not convert jsonl files to json")
 def run(
     profile: str,
     rate: float,
@@ -53,8 +53,8 @@ def run(
         config.autoware_path,
         rate,
         delay,
-        not no_json,
         perception_mode,
+        not no_json,
     )
 
 

--- a/driving_log_replayer_cli/simulation/generate.py
+++ b/driving_log_replayer_cli/simulation/generate.py
@@ -16,14 +16,6 @@ class AutowareEssentialParameter:
 
 
 class TestScriptGenerator:
-    PERCEPTION_MODES = (
-        "camera_lidar_radar_fusion",
-        "camera_lidar_fusion",
-        "lidar_radar_fusion",
-        "lidar",
-        "radar",
-    )
-
     USE_T4_DATASET = ("perception", "obstacle_segmentation", "perception_2d", "traffic_light")
 
     def __init__(
@@ -33,6 +25,7 @@ class TestScriptGenerator:
         autoware_path: str,
         rate: float,
         delay: float,
+        perception_mode: str,
     ) -> None:
         self.__data_directory = Path(data_directory)
         self.__output_directory = Path(output_directory)
@@ -40,6 +33,7 @@ class TestScriptGenerator:
         self.__script_path = self.__output_directory.joinpath("run.bash")
         self.__rate = rate
         self.__delay = delay
+        self.__perception_mode = perception_mode
         #  os.path.join(config.output_directory, datetime.datetime.now().strftime("%Y-%m%d-%H%M%S"))が渡ってくるので被ることはない
         self.__output_directory.mkdir(parents=True)
 
@@ -216,14 +210,7 @@ rviz:=true\
 
             use_case_name = scenario_yaml_obj["Evaluation"]["UseCaseName"]
             launch_base_command = f"ros2 launch driving_log_replayer {use_case_name}.launch.py "
-            optional_arg = ""
-            perception_mode: str | None = scenario_yaml_obj.get("PerceptionMode")
-            if perception_mode is not None:
-                assert perception_mode in self.PERCEPTION_MODES, (
-                    f"perception_mode must be chosen from {self.PERCEPTION_MODES}, "
-                    f"but got {perception_mode}"
-                )
-                optional_arg = f"perception_mode:={perception_mode} "
+            optional_arg = f"perception_mode:={self.__perception_mode} "
             launch_args = self._create_common_arg(
                 optional_arg,
                 scenario_path,

--- a/driving_log_replayer_cli/simulation/run.py
+++ b/driving_log_replayer_cli/simulation/run.py
@@ -17,47 +17,24 @@ class DrivingLogReplayerTestRunner:
         rate: float,
         delay: float,
         output_json: bool,  # noqa
+        perception_mode: str,
     ) -> None:
-        self.__data_directory = data_directory
-        self.__output_directory = output_directory
-        self.__autoware_path = autoware_path
-        self.__rate = rate
-        self.__delay = delay
-        self.__output_json = output_json
-
         termcolor.cprint("<< generating launch command >>", "green")
         generator = TestScriptGenerator(
-            self.__data_directory,
-            self.__output_directory,
-            self.__autoware_path,
-            self.__rate,
-            self.__delay,
+            data_directory,
+            output_directory,
+            autoware_path,
+            rate,
+            delay,
+            perception_mode,
         )
         is_executable = generator.run()
-        if is_executable:
-            cmd = "/bin/bash " + generator.script_path.as_posix()
-            subprocess.run(cmd, shell=True)
-            if self.__output_json:
-                convert(self.__output_directory)
-            termcolor.cprint("<< show test result >>", "green")
-            display(self.__output_directory)
-        else:
+        if not is_executable:
             print("aborted.")  # noqa
-
-
-def run(
-    data_directory: str,
-    output_directory: str,
-    autoware_path: str,
-    rate: float,
-    delay: float,
-    output_json: bool,  # noqa
-) -> None:
-    DrivingLogReplayerTestRunner(
-        os.path.expandvars(data_directory),
-        os.path.expandvars(output_directory),
-        os.path.expandvars(autoware_path),
-        rate,
-        delay,
-        output_json=output_json,
-    )
+            return
+        cmd = "/bin/bash " + generator.script_path.as_posix()
+        subprocess.run(cmd, shell=True)
+        if output_json:
+            convert(self.__output_directory)
+        termcolor.cprint("<< show test result >>", "green")
+        display(self.__output_directory)

--- a/driving_log_replayer_cli/simulation/run.py
+++ b/driving_log_replayer_cli/simulation/run.py
@@ -16,8 +16,8 @@ class DrivingLogReplayerTestRunner:
         autoware_path: str,
         rate: float,
         delay: float,
-        output_json: bool,  # noqa
         perception_mode: str,
+        output_json: bool,  # noqa
     ) -> None:
         self.__data_directory = expandvars(data_directory)
         self.__output_directory = expandvars(output_directory)

--- a/driving_log_replayer_cli/simulation/run.py
+++ b/driving_log_replayer_cli/simulation/run.py
@@ -1,4 +1,4 @@
-import os
+from os.path import expandvars
 import subprocess
 
 import termcolor
@@ -19,11 +19,14 @@ class DrivingLogReplayerTestRunner:
         output_json: bool,  # noqa
         perception_mode: str,
     ) -> None:
+        self.__data_directory = expandvars(data_directory)
+        self.__output_directory = expandvars(output_directory)
+        self.__autoware_path = expandvars(autoware_path)
         termcolor.cprint("<< generating launch command >>", "green")
         generator = TestScriptGenerator(
-            data_directory,
-            output_directory,
-            autoware_path,
+            self.__data_directory,
+            self.__output_directory,
+            self.__autoware_path,
             rate,
             delay,
             perception_mode,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "driving_log_replayer_cli"
-version = "1.8.3"
+version = "1.8.4"
 description = "command line tool for driving_log_replayer"
 authors = [
   "Hayato Mizushima <hayato.mizushima@tier4.jp>",

--- a/sample/perception/scenario.fp.ja.yaml
+++ b/sample/perception/scenario.fp.ja.yaml
@@ -1,9 +1,8 @@
-ScenarioFormatVersion: 3.1.0
+ScenarioFormatVersion: 3.0.0
 ScenarioName: fp_sample
 ScenarioDescription: fp_sample
 SensorModel: sample_sensor_kit
 VehicleModel: sample_vehicle
-PerceptionMode: lidar
 Evaluation:
   UseCaseName: perception
   UseCaseFormatVersion: 0.6.0

--- a/sample/perception/scenario.fp.yaml
+++ b/sample/perception/scenario.fp.yaml
@@ -1,9 +1,8 @@
-ScenarioFormatVersion: 3.1.0
+ScenarioFormatVersion: 3.0.0
 ScenarioName: fp_sample
 ScenarioDescription: fp_sample
 SensorModel: sample_sensor_kit
 VehicleModel: sample_vehicle
-PerceptionMode: lidar
 Evaluation:
   UseCaseName: perception
   UseCaseFormatVersion: 0.6.0

--- a/sample/perception/scenario.ja.yaml
+++ b/sample/perception/scenario.ja.yaml
@@ -1,9 +1,8 @@
-ScenarioFormatVersion: 3.1.0
+ScenarioFormatVersion: 3.0.0
 ScenarioName: perception_use_bag_concat_data
 ScenarioDescription: sensing_module_off_and_use_pointcloud_in_the_rosbag
 SensorModel: sample_sensor_kit
 VehicleModel: sample_vehicle
-PerceptionMode: lidar
 Evaluation:
   UseCaseName: perception
   UseCaseFormatVersion: 0.6.0

--- a/sample/perception/scenario.yaml
+++ b/sample/perception/scenario.yaml
@@ -1,9 +1,8 @@
-ScenarioFormatVersion: 3.1.0
+ScenarioFormatVersion: 3.0.0
 ScenarioName: perception_use_bag_concat_data
 ScenarioDescription: sensing_module_off_and_use_pointcloud_in_the_rosbag
 SensorModel: sample_sensor_kit
 VehicleModel: sample_vehicle
-PerceptionMode: lidar
 Evaluation:
   UseCaseName: perception
   UseCaseFormatVersion: 0.6.0

--- a/sample/perception_2d/scenario.ja.yaml
+++ b/sample/perception_2d/scenario.ja.yaml
@@ -1,9 +1,8 @@
-ScenarioFormatVersion: 3.1.0
+ScenarioFormatVersion: 3.0.0
 ScenarioName: perception_2d_x2
 ScenarioDescription: perception_2d_x2
 SensorModel: aip_x2
 VehicleModel: gsm8
-PerceptionMode: camera_lidar_fusion
 Evaluation:
   UseCaseName: perception_2d
   UseCaseFormatVersion: 0.3.0

--- a/sample/perception_2d/scenario.yaml
+++ b/sample/perception_2d/scenario.yaml
@@ -1,9 +1,8 @@
-ScenarioFormatVersion: 3.1.0
+ScenarioFormatVersion: 3.0.0
 ScenarioName: perception_2d_x2
 ScenarioDescription: perception_2d_x2
 SensorModel: aip_x2
 VehicleModel: gsm8
-PerceptionMode: camera_lidar_fusion
 Evaluation:
   UseCaseName: perception_2d
   UseCaseFormatVersion: 0.3.0


### PR DESCRIPTION
## Types of PR

- [x] New Features

## Description

- downgrade scenario format (3.1.0 -> 3.0.0)
  - revert https://github.com/tier4/driving_log_replayer/pull/279
- add perception mode to simulation run argument

## How to review this PR

- You can specify the perception_mode with the -m or --perception-mode option.
- However, perception_2d is currently fixed with `camera_lidar_fusion`, no matter what is passed to perception_mode.
  - https://github.com/tier4/driving_log_replayer/blob/develop/driving_log_replayer/launch/perception_2d.launch.py#L33

## Others

```shell
❯ driving_log_replayer simulation run -p perception -m camera_lidar_fusion --rate 0.5
$HOME/out/perception/2023-1108-144009
<< generating launch command >>
launch command generated! => ros2 launch driving_log_replayer perception.launch.py perception_mode:=camera_lidar_fusion scenario_path:=/home/hyt/data/perception/sample/scenario.yaml result_json_path:=/home/hyt/out/perception/2023-1108-144009/sample/sample_dataset/result.json play_rate:=0.5 play_delay:=10.0 input_bag:=/home/hyt/data/perception/sample/t4_dataset/sample_dataset/input_bag result_bag_path:=/home/hyt/out/perception/2023-1108-144009/sample/sample_dataset/result_bag map_path:=/home/hyt/map/oss vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit vehicle_id:=default rviz:=true t4_dataset_path:=/home/hyt/data/perception/sample/t4_dataset/sample_dataset result_archive_path:=/home/hyt/out/perception/2023-1108-144009/sample/sample_dataset/result_archive sensing:=False



❯ driving_log_replayer simulation run -p perception --rate 0.5
$HOME/out/perception/2023-1108-144541
<< generating launch command >>
launch command generated! => ros2 launch driving_log_replayer perception.launch.py perception_mode:=lidar scenario_path:=/home/hyt/data/perception/sample/scenario.yaml result_json_path:=/home/hyt/out/perception/2023-1108-144541/sample/sample_dataset/result.json play_rate:=0.5 play_delay:=10.0 input_bag:=/home/hyt/data/perception/sample/t4_dataset/sample_dataset/input_bag result_bag_path:=/home/hyt/out/perception/2023-1108-144541/sample/sample_dataset/result_bag map_path:=/home/hyt/map/oss vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit vehicle_id:=default rviz:=true t4_dataset_path:=/home/hyt/data/perception/sample/t4_dataset/sample_dataset result_archive_path:=/home/hyt/out/perception/2023-1108-144541/sample/sample_dataset/result_archive sensing:=False
```
