### PR TITLE
feat: override record topics

### DIFF
--- a/driving_log_replayer/driving_log_replayer/launch_common.py
+++ b/driving_log_replayer/driving_log_replayer/launch_common.py
@@ -106,7 +106,7 @@ def get_driving_log_replayer_common_argument() -> list:
     add_launch_arg(
         "override_topics_regex",
         default_value="",
-        description="use allowlist. Ex: override_topics_regex:=\^/clock\$\|\^/tf\$\|/sensing/lidar/concatenated/pointcloud",
+        description="use allowlist. Ex: override_topics_regex:=\^/clock\$\|\^/tf\$\|/sensing/lidar/concatenated/pointcloud",  # noqa
     )
 
     return launch_arguments

--- a/driving_log_replayer/driving_log_replayer/launch_common.py
+++ b/driving_log_replayer/driving_log_replayer/launch_common.py
@@ -50,6 +50,7 @@ def get_driving_log_replayer_common_argument() -> list:
     t4_dataset_path
     result_archive_path
     override_record_topics
+    override_topics_regex
 
     """
     launch_arguments = []

--- a/driving_log_replayer/driving_log_replayer/launch_common.py
+++ b/driving_log_replayer/driving_log_replayer/launch_common.py
@@ -46,6 +46,10 @@ def get_driving_log_replayer_common_argument() -> list:
     vehicle_model
     sensor_model
     vehicle_id
+    perception_mode
+    t4_dataset_path
+    result_archive_path
+    override_record_topics
 
     """
     launch_arguments = []
@@ -89,11 +93,20 @@ def get_driving_log_replayer_common_argument() -> list:
         default_value="/opt/autoware/t4_dataset",
         description="full path of t4_dataset",
     )
-
     add_launch_arg(
         "result_archive_path",
         default_value="/opt/autoware/result_archive",
         description="additional result file",
+    )
+    add_launch_arg(
+        "override_record_topics",
+        default_value="false",
+        description="flag of override record topics",
+    )
+    add_launch_arg(
+        "override_topics_regex",
+        default_value="",
+        description="use allowlist. Ex: override_topics_regex:=^/clock$|^/tf$|/sensing/lidar/concatenated/pointcloud|^/perception/object_recognition/detection/objects$",
     )
 
     return launch_arguments
@@ -218,8 +231,8 @@ def get_recorder(record_config_name: str, record_topics: list) -> ExecuteProcess
     return ExecuteProcess(cmd=record_cmd)
 
 
-def get_regex_recorder(record_config_name: str, allowlist: str) -> ExecuteProcess:
-    record_cmd = [
+def create_regex_record_cmd(record_config_name: str, allowlist: str) -> list:
+    return [
         "ros2",
         "bag",
         "record",
@@ -234,6 +247,10 @@ def get_regex_recorder(record_config_name: str, allowlist: str) -> ExecuteProces
         "-e",
         allowlist,
     ]
+
+
+def get_regex_recorder(record_config_name: str, allowlist: str) -> ExecuteProcess:
+    record_cmd = create_regex_record_cmd(record_config_name, allowlist)
     return ExecuteProcess(cmd=record_cmd)
 
 

--- a/driving_log_replayer/driving_log_replayer/launch_common.py
+++ b/driving_log_replayer/driving_log_replayer/launch_common.py
@@ -213,24 +213,6 @@ def get_evaluator_node(
     )
 
 
-def get_recorder(record_config_name: str, record_topics: list) -> ExecuteProcess:
-    record_cmd = [
-        "ros2",
-        "bag",
-        "record",
-        *record_topics,
-        "-o",
-        LaunchConfiguration("result_bag_path"),
-        "--qos-profile-overrides-path",
-        Path(
-            get_package_share_directory("driving_log_replayer"),
-            "config",
-            record_config_name,
-        ).as_posix(),
-    ]
-    return ExecuteProcess(cmd=record_cmd)
-
-
 def create_regex_record_cmd(record_config_name: str, allowlist: str) -> list:
     return [
         "ros2",

--- a/driving_log_replayer/driving_log_replayer/launch_common.py
+++ b/driving_log_replayer/driving_log_replayer/launch_common.py
@@ -106,7 +106,7 @@ def get_driving_log_replayer_common_argument() -> list:
     add_launch_arg(
         "override_topics_regex",
         default_value="",
-        description="use allowlist. Ex: override_topics_regex:=^/clock$|^/tf$|/sensing/lidar/concatenated/pointcloud|^/perception/object_recognition/detection/objects$",
+        description="use allowlist. Ex: override_topics_regex:=\^/clock\$\|\^/tf\$\|/sensing/lidar/concatenated/pointcloud",
     )
 
     return launch_arguments

--- a/driving_log_replayer/launch/ar_tag_based_localizer.launch.py
+++ b/driving_log_replayer/launch/ar_tag_based_localizer.launch.py
@@ -33,7 +33,7 @@ def generate_launch_description() -> launch.LaunchDescription:
     rviz_node = driving_log_replayer.launch_common.get_rviz("localization.rviz")
     evaluator_node = driving_log_replayer.launch_common.get_evaluator_node("ar_tag_based_localizer")
     player = driving_log_replayer.launch_common.get_player()
-    recorder = driving_log_replayer.launch_common.get_regex_recorder(
+    recorder, recorder_override = driving_log_replayer.launch_common.get_regex_recorders(
         "localization.qos.yaml",
         RECORD_TOPIC_REGEX,
     )
@@ -46,6 +46,7 @@ def generate_launch_description() -> launch.LaunchDescription:
             fitter_launch,
             evaluator_node,
             recorder,
+            recorder_override,
             player,
         ],
     )

--- a/driving_log_replayer/launch/ar_tag_based_localizer.launch.py
+++ b/driving_log_replayer/launch/ar_tag_based_localizer.launch.py
@@ -19,7 +19,7 @@ import driving_log_replayer.launch_common
 RECORD_TOPIC_REGEX = """^/clock$\
 |^/tf$\
 |^/diagnostics$"\
-|^/localization/kinematic_state$
+|^/localization/kinematic_state$\
 """
 
 

--- a/driving_log_replayer/launch/ar_tag_based_localizer.launch.py
+++ b/driving_log_replayer/launch/ar_tag_based_localizer.launch.py
@@ -16,6 +16,12 @@ import launch
 
 import driving_log_replayer.launch_common
 
+RECORD_TOPIC_REGEX = """^/clock$\
+|^/tf$\
+|^/diagnostics$"\
+|^/localization/kinematic_state$
+"""
+
 
 def generate_launch_description() -> launch.LaunchDescription:
     launch_arguments = driving_log_replayer.launch_common.get_driving_log_replayer_common_argument()
@@ -27,14 +33,9 @@ def generate_launch_description() -> launch.LaunchDescription:
     rviz_node = driving_log_replayer.launch_common.get_rviz("localization.rviz")
     evaluator_node = driving_log_replayer.launch_common.get_evaluator_node("ar_tag_based_localizer")
     player = driving_log_replayer.launch_common.get_player()
-    recorder = driving_log_replayer.launch_common.get_recorder(
+    recorder = driving_log_replayer.launch_common.get_regex_recorder(
         "localization.qos.yaml",
-        [
-            "/clock",
-            "/tf",
-            "/localization/kinematic_state",
-            "/diagnostics",
-        ],
+        RECORD_TOPIC_REGEX,
     )
 
     return launch.LaunchDescription(

--- a/driving_log_replayer/launch/ar_tag_based_localizer.launch.py
+++ b/driving_log_replayer/launch/ar_tag_based_localizer.launch.py
@@ -45,8 +45,8 @@ def generate_launch_description() -> launch.LaunchDescription:
             autoware_launch,
             fitter_launch,
             evaluator_node,
+            player,
             recorder,
             recorder_override,
-            player,
         ],
     )

--- a/driving_log_replayer/launch/eagleye.launch.py
+++ b/driving_log_replayer/launch/eagleye.launch.py
@@ -49,8 +49,8 @@ def generate_launch_description() -> launch.LaunchDescription:
             autoware_launch,
             fitter_launch,
             evaluator_node,
+            player,
             recorder,
             recorder_override,
-            player,
         ],
     )

--- a/driving_log_replayer/launch/eagleye.launch.py
+++ b/driving_log_replayer/launch/eagleye.launch.py
@@ -37,7 +37,7 @@ def generate_launch_description() -> launch.LaunchDescription:
     rviz_node = driving_log_replayer.launch_common.get_rviz("localization.rviz")
     evaluator_node = driving_log_replayer.launch_common.get_evaluator_node("eagleye")
     player = driving_log_replayer.launch_common.get_player()
-    recorder = driving_log_replayer.launch_common.get_regex_recorders(
+    recorder, recorder_override = driving_log_replayer.launch_common.get_regex_recorders(
         "localization.qos.yaml",
         RECORD_TOPIC_REGEX,
     )
@@ -50,6 +50,7 @@ def generate_launch_description() -> launch.LaunchDescription:
             fitter_launch,
             evaluator_node,
             recorder,
+            recorder_override,
             player,
         ],
     )

--- a/driving_log_replayer/launch/eagleye.launch.py
+++ b/driving_log_replayer/launch/eagleye.launch.py
@@ -16,6 +16,15 @@ import launch
 
 import driving_log_replayer.launch_common
 
+RECORD_TOPIC_REGEX = """^/clock$\
+|^/tf$\
+|^/diagnostics$"\
+|^/localization/kinematic_state$\
+|^/localization/pose_estimator/pose$\
+|^/localization/util/downsample/pointcloud$\
+|^/localization/pose_estimator/points_aligned$
+"""
+
 
 def generate_launch_description() -> launch.LaunchDescription:
     launch_arguments = driving_log_replayer.launch_common.get_driving_log_replayer_common_argument()
@@ -28,17 +37,9 @@ def generate_launch_description() -> launch.LaunchDescription:
     rviz_node = driving_log_replayer.launch_common.get_rviz("localization.rviz")
     evaluator_node = driving_log_replayer.launch_common.get_evaluator_node("eagleye")
     player = driving_log_replayer.launch_common.get_player()
-    recorder = driving_log_replayer.launch_common.get_recorder(
+    recorder = driving_log_replayer.launch_common.get_regex_recorders(
         "localization.qos.yaml",
-        [
-            "/clock",
-            "/tf",
-            "/localization/pose_estimator/pose",
-            "/localization/kinematic_state",
-            "/localization/util/downsample/pointcloud",
-            "/localization/pose_estimator/points_aligned",
-            "/diagnostics",
-        ],
+        RECORD_TOPIC_REGEX,
     )
 
     return launch.LaunchDescription(

--- a/driving_log_replayer/launch/eagleye.launch.py
+++ b/driving_log_replayer/launch/eagleye.launch.py
@@ -22,7 +22,7 @@ RECORD_TOPIC_REGEX = """^/clock$\
 |^/localization/kinematic_state$\
 |^/localization/pose_estimator/pose$\
 |^/localization/util/downsample/pointcloud$\
-|^/localization/pose_estimator/points_aligned$
+|^/localization/pose_estimator/points_aligned$\
 """
 
 

--- a/driving_log_replayer/launch/localization.launch.py
+++ b/driving_log_replayer/launch/localization.launch.py
@@ -16,6 +16,17 @@ import launch
 
 import driving_log_replayer.launch_common
 
+RECORD_TOPIC_REGEX = """^/clock$\
+|^/tf$\
+|^/localization/pose_estimator/transform_probability$\
+|^/localization/pose_estimator/nearest_voxel_transformation_likelihood$\
+|^/localization/pose_estimator/pose$\
+|^/localization/kinematic_state$\
+|^/localization/util/downsample/pointcloud$\
+|^/localization/pose_estimator/points_aligned$\
+|^/driving_log_replayer/localization/lateral_distance
+"""
+
 
 def generate_launch_description() -> launch.LaunchDescription:
     launch_arguments = driving_log_replayer.launch_common.get_driving_log_replayer_common_argument()
@@ -24,19 +35,9 @@ def generate_launch_description() -> launch.LaunchDescription:
     rviz_node = driving_log_replayer.launch_common.get_rviz("localization.rviz")
     evaluator_node = driving_log_replayer.launch_common.get_evaluator_node("localization")
     player = driving_log_replayer.launch_common.get_player()
-    recorder = driving_log_replayer.launch_common.get_recorder(
+    recorder = driving_log_replayer.launch_common.get_regex_recorders(
         "localization.qos.yaml",
-        [
-            "/clock",
-            "/tf",
-            "/localization/pose_estimator/transform_probability",
-            "/localization/pose_estimator/nearest_voxel_transformation_likelihood",
-            "/localization/pose_estimator/pose",
-            "/localization/kinematic_state",
-            "/localization/util/downsample/pointcloud",
-            "/localization/pose_estimator/points_aligned",
-            "/driving_log_replayer/localization/lateral_distance",
-        ],
+        RECORD_TOPIC_REGEX,
     )
     topic_monitor = driving_log_replayer.launch_common.get_topic_state_monitor_launch(
         "localization_topics.yaml",

--- a/driving_log_replayer/launch/localization.launch.py
+++ b/driving_log_replayer/launch/localization.launch.py
@@ -24,7 +24,7 @@ RECORD_TOPIC_REGEX = """^/clock$\
 |^/localization/kinematic_state$\
 |^/localization/util/downsample/pointcloud$\
 |^/localization/pose_estimator/points_aligned$\
-|^/driving_log_replayer/.*
+|^/driving_log_replayer/.*\
 """
 
 

--- a/driving_log_replayer/launch/localization.launch.py
+++ b/driving_log_replayer/launch/localization.launch.py
@@ -24,7 +24,7 @@ RECORD_TOPIC_REGEX = """^/clock$\
 |^/localization/kinematic_state$\
 |^/localization/util/downsample/pointcloud$\
 |^/localization/pose_estimator/points_aligned$\
-|^/driving_log_replayer/localization/lateral_distance
+|^/driving_log_replayer/.*
 """
 
 

--- a/driving_log_replayer/launch/localization.launch.py
+++ b/driving_log_replayer/launch/localization.launch.py
@@ -50,9 +50,9 @@ def generate_launch_description() -> launch.LaunchDescription:
             autoware_launch,
             fitter_launch,
             evaluator_node,
+            player,
             recorder,
             recorder_override,
-            player,
             topic_monitor,
         ],
     )

--- a/driving_log_replayer/launch/localization.launch.py
+++ b/driving_log_replayer/launch/localization.launch.py
@@ -35,7 +35,7 @@ def generate_launch_description() -> launch.LaunchDescription:
     rviz_node = driving_log_replayer.launch_common.get_rviz("localization.rviz")
     evaluator_node = driving_log_replayer.launch_common.get_evaluator_node("localization")
     player = driving_log_replayer.launch_common.get_player()
-    recorder = driving_log_replayer.launch_common.get_regex_recorders(
+    recorder, recorder_override = driving_log_replayer.launch_common.get_regex_recorders(
         "localization.qos.yaml",
         RECORD_TOPIC_REGEX,
     )
@@ -51,6 +51,7 @@ def generate_launch_description() -> launch.LaunchDescription:
             fitter_launch,
             evaluator_node,
             recorder,
+            recorder_override,
             player,
             topic_monitor,
         ],

--- a/driving_log_replayer/launch/obstacle_segmentation.launch.py
+++ b/driving_log_replayer/launch/obstacle_segmentation.launch.py
@@ -19,6 +19,14 @@ from launch_ros.actions import Node
 import driving_log_replayer.launch_common
 from driving_log_replayer.shutdown_once import ShutdownOnce
 
+RECORD_TOPIC_REGEX = """^/clock$\
+|^/tf$\
+|^/perception/obstacle_segmentation/pointcloud$\
+|^/planning/scenario_planning/trajectory$\
+|^/planning/scenario_planning/status/stop_reasons$\
+|^/driving_log_replayer/.*
+"""
+
 
 def generate_launch_description() -> launch.LaunchDescription:
     launch_arguments = driving_log_replayer.launch_common.get_driving_log_replayer_common_argument()
@@ -49,23 +57,9 @@ def generate_launch_description() -> launch.LaunchDescription:
         ],
     )
 
-    recorder = driving_log_replayer.launch_common.get_recorder(
+    recorder = driving_log_replayer.launch_common.get_regex_recorder(
         "obstacle_segmentation.qos.yaml",
-        [
-            "/clock",
-            "/tf",
-            "/perception/obstacle_segmentation/pointcloud",
-            "/planning/scenario_planning/status/stop_reasons",
-            "/planning/scenario_planning/trajectory",
-            "/driving_log_replayer/marker/detection",
-            "/driving_log_replayer/marker/non_detection",
-            "/driving_log_replayer/pcd/detection",
-            "/driving_log_replayer/pcd/non_detection",
-            "/driving_log_replayer/obstacle_segmentation/input",
-            "/driving_log_replayer/graph/topic_rate",
-            "/driving_log_replayer/graph/detection",
-            "/driving_log_replayer/graph/non_detection",
-        ],
+        RECORD_TOPIC_REGEX,
     )
 
     return launch.LaunchDescription(

--- a/driving_log_replayer/launch/obstacle_segmentation.launch.py
+++ b/driving_log_replayer/launch/obstacle_segmentation.launch.py
@@ -57,7 +57,7 @@ def generate_launch_description() -> launch.LaunchDescription:
         ],
     )
 
-    recorder = driving_log_replayer.launch_common.get_regex_recorder(
+    recorder, recorder_override = driving_log_replayer.launch_common.get_regex_recorders(
         "obstacle_segmentation.qos.yaml",
         RECORD_TOPIC_REGEX,
     )
@@ -71,5 +71,6 @@ def generate_launch_description() -> launch.LaunchDescription:
             evaluator_sub_node,
             player,
             recorder,
+            recorder_override,
         ],
     )

--- a/driving_log_replayer/launch/obstacle_segmentation.launch.py
+++ b/driving_log_replayer/launch/obstacle_segmentation.launch.py
@@ -24,7 +24,7 @@ RECORD_TOPIC_REGEX = """^/clock$\
 |^/perception/obstacle_segmentation/pointcloud$\
 |^/planning/scenario_planning/trajectory$\
 |^/planning/scenario_planning/status/stop_reasons$\
-|^/driving_log_replayer/.*
+|^/driving_log_replayer/.*\
 """
 
 

--- a/driving_log_replayer/launch/perception.launch.py
+++ b/driving_log_replayer/launch/perception.launch.py
@@ -27,7 +27,7 @@ RECORD_TOPIC_REGEX = """^/clock$\
 |^/perception/object_recognition/tracking/objects$\
 |^/perception/object_recognition/objects$\
 |^/driving_log_replayer/.*\
-|^/sensing/camera/.*
+|^/sensing/camera/.*\
 """
 
 

--- a/driving_log_replayer/launch/perception.launch.py
+++ b/driving_log_replayer/launch/perception.launch.py
@@ -20,7 +20,15 @@ from launch.substitutions import LaunchConfiguration
 
 import driving_log_replayer.launch_common
 
-RECORD_TOPIC_REGEX = "^/clock$|^/tf$|/sensing/lidar/concatenated/pointcloud|^/perception/object_recognition/detection/objects$|^/perception/object_recognition/tracking/objects$|^/perception/object_recognition/objects$|^/driving_log_replayer/.*|^/sensing/camera/.*"
+RECORD_TOPIC_REGEX = """^/clock$\
+|^/tf$\
+|^/sensing/lidar/concatenated/pointcloud$\
+|^/perception/object_recognition/detection/objects$\
+|^/perception/object_recognition/tracking/objects$\
+|^/perception/object_recognition/objects$\
+|^/driving_log_replayer/.*\
+|^/sensing/camera/.*
+"""
 
 
 def generate_launch_description() -> launch.LaunchDescription:

--- a/driving_log_replayer/launch/perception.launch.py
+++ b/driving_log_replayer/launch/perception.launch.py
@@ -66,9 +66,24 @@ def generate_launch_description() -> launch.LaunchDescription:
         condition=IfCondition(LaunchConfiguration("sensing")),
     )
 
-    recorder = driving_log_replayer.launch_common.get_regex_recorder(
+    record_cmd = driving_log_replayer.launch_common.create_regex_record_cmd(
         "perception.qos.yaml",
         "^/clock$|^/tf$|/sensing/lidar/concatenated/pointcloud|^/perception/object_recognition/detection/objects$|^/perception/object_recognition/tracking/objects$|^/perception/object_recognition/objects$|^/driving_log_replayer/.*|^/sensing/camera/.*",
+    )
+
+    recorder = ExecuteProcess(
+        cmd=record_cmd,
+        condition=UnlessCondition(LaunchConfiguration("override_record_topics")),
+    )
+
+    record_override_cmd = driving_log_replayer.launch_common.create_regex_record_cmd(
+        "perception.qos.yaml",
+        LaunchConfiguration("override_topics_regex"),
+    )
+
+    recorder_override = ExecuteProcess(
+        cmd=record_override_cmd,
+        condition=IfCondition(LaunchConfiguration("override_record_topics")),
     )
 
     return launch.LaunchDescription(
@@ -80,5 +95,6 @@ def generate_launch_description() -> launch.LaunchDescription:
             player_normal,
             player_remap,
             recorder,
+            recorder_override,
         ],
     )

--- a/driving_log_replayer/launch/perception_2d.launch.py
+++ b/driving_log_replayer/launch/perception_2d.launch.py
@@ -68,5 +68,6 @@ def generate_launch_description() -> launch.LaunchDescription:
             player_normal,
             player_remap,
             recorder,
+            recorder_override,
         ],
     )

--- a/driving_log_replayer/launch/perception_2d.launch.py
+++ b/driving_log_replayer/launch/perception_2d.launch.py
@@ -27,7 +27,7 @@ RECORD_TOPIC_REGEX = """^/clock$\
 |^/perception/object_recognition/tracking/objects$\
 |^/perception/object_recognition/objects$\
 |^/sensing/camera/.*\
-|^/driving_log_replayer/.*
+|^/driving_log_replayer/.*\
 """
 
 

--- a/driving_log_replayer/launch/performance_diag.launch.py
+++ b/driving_log_replayer/launch/performance_diag.launch.py
@@ -86,9 +86,9 @@ def generate_launch_description() -> launch.LaunchDescription:
             autoware_launch,
             fitter_launch,
             evaluator_node,
-            recorder,
-            recorder_override,
             player_normal,
             player_remap,
+            recorder,
+            recorder_override,
         ],
     )

--- a/driving_log_replayer/launch/performance_diag.launch.py
+++ b/driving_log_replayer/launch/performance_diag.launch.py
@@ -75,7 +75,7 @@ def generate_launch_description() -> launch.LaunchDescription:
         condition=IfCondition(LaunchConfiguration("localization")),
     )
 
-    recorder = driving_log_replayer.launch_common.get_regex_recorder(
+    recorder, recorder_override = driving_log_replayer.launch_common.get_regex_recorders(
         "performance_diag.qos.yaml",
         RECORD_TOPIC_REGEX,
     )
@@ -87,6 +87,7 @@ def generate_launch_description() -> launch.LaunchDescription:
             fitter_launch,
             evaluator_node,
             recorder,
+            recorder_override,
             player_normal,
             player_remap,
         ],

--- a/driving_log_replayer/launch/performance_diag.launch.py
+++ b/driving_log_replayer/launch/performance_diag.launch.py
@@ -23,6 +23,15 @@ from launch.substitutions import LaunchConfiguration
 
 import driving_log_replayer.launch_common
 
+RECORD_TOPIC_REGEX = """^/clock$\
+|^/tf$\
+|^/perception/obstacle_segmentation/pointcloud$\
+|^/sensing/lidar/concatenated/pointcloud$\
+|^/diagnostics_agg$\
+|^/sensing/lidar/.*/blockage_diag/debug/blockage_mask_image$\
+|^/driving_log_replayer/.*
+"""
+
 
 def generate_launch_description() -> launch.LaunchDescription:
     launch_arguments = driving_log_replayer.launch_common.get_driving_log_replayer_common_argument()
@@ -68,7 +77,7 @@ def generate_launch_description() -> launch.LaunchDescription:
 
     recorder = driving_log_replayer.launch_common.get_regex_recorder(
         "performance_diag.qos.yaml",
-        "^/clock$|^/tf$|/perception/obstacle_segmentation/pointcloud|/sensing/lidar/concatenated/pointcloud|^/diagnostics$|^/diagnostics_agg$|^/driving_log_replayer/.*|^/sensing/lidar/.*/blockage_diag/debug/blockage_mask_image$",
+        RECORD_TOPIC_REGEX,
     )
     return launch.LaunchDescription(
         [

--- a/driving_log_replayer/launch/performance_diag.launch.py
+++ b/driving_log_replayer/launch/performance_diag.launch.py
@@ -29,7 +29,7 @@ RECORD_TOPIC_REGEX = """^/clock$\
 |^/sensing/lidar/concatenated/pointcloud$\
 |^/diagnostics_agg$\
 |^/sensing/lidar/.*/blockage_diag/debug/blockage_mask_image$\
-|^/driving_log_replayer/.*
+|^/driving_log_replayer/.*\
 """
 
 

--- a/driving_log_replayer/launch/traffic_light.launch.py
+++ b/driving_log_replayer/launch/traffic_light.launch.py
@@ -27,7 +27,7 @@ RECORD_TOPIC_REGEX = """^/clock$\
 |^/perception/object_recognition/tracking/objects$\
 |^/perception/object_recognition/objects$\
 |^/sensing/camera/.*"\
-|^/driving_log_replayer/.*
+|^/driving_log_replayer/.*\
 """
 
 

--- a/driving_log_replayer/launch/traffic_light.launch.py
+++ b/driving_log_replayer/launch/traffic_light.launch.py
@@ -12,16 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
-
 import launch
 from launch.actions import DeclareLaunchArgument
-from launch.actions import ExecuteProcess
 from launch.conditions import IfCondition
 from launch.conditions import UnlessCondition
 from launch.substitutions import LaunchConfiguration
 
 import driving_log_replayer.launch_common
+
+RECORD_TOPIC_REGEX = """^/clock$\
+|^/tf$\
+|^/sensing/lidar/concatenated/pointcloud$\
+|^/perception/object_recognition/detection/objects$\
+|^/perception/object_recognition/tracking/objects$\
+|^/perception/object_recognition/objects$\
+|^/sensing/camera/.*"\
+|^/driving_log_replayer/.*
+"""
 
 
 def generate_launch_description() -> launch.LaunchDescription:
@@ -34,41 +41,21 @@ def generate_launch_description() -> launch.LaunchDescription:
     rviz_node = driving_log_replayer.launch_common.get_rviz("perception.rviz")
     evaluator_node = driving_log_replayer.launch_common.get_evaluator_node("traffic_light")
 
-    play_cmd = [
-        "ros2",
-        "bag",
-        "play",
-        LaunchConfiguration("input_bag"),
-        "--rate",
-        LaunchConfiguration("play_rate"),
-        "--clock",
-        "200",
-    ]
-    play_cmd_remap = copy.copy(play_cmd)
-    play_cmd_remap.extend(
-        [
-            "--remap",
-            "/sensing/lidar/concatenated/pointcloud:=/driving_log_replayer/concatenated/pointcloud",
-        ],
-    )
-
-    player_normal = ExecuteProcess(
-        cmd=["sleep", LaunchConfiguration("play_delay")],
-        on_exit=[ExecuteProcess(cmd=play_cmd)],
-        output="screen",
+    player_normal = driving_log_replayer.launch_common.get_player(
         condition=UnlessCondition(LaunchConfiguration("sensing")),
     )
 
-    player_remap = ExecuteProcess(
-        cmd=["sleep", LaunchConfiguration("play_delay")],
-        on_exit=[ExecuteProcess(cmd=play_cmd_remap)],
-        output="screen",
+    player_remap = driving_log_replayer.launch_common.get_player(
+        additional_argument=[
+            "--remap",
+            "/sensing/lidar/concatenated/pointcloud:=/driving_log_replayer/concatenated/pointcloud",
+        ],
         condition=IfCondition(LaunchConfiguration("sensing")),
     )
 
-    recorder = driving_log_replayer.launch_common.get_regex_recorder(
+    recorder, recorder_override = driving_log_replayer.launch_common.get_regex_recorders(
         "perception.qos.yaml",
-        "^/clock$|^/tf$|/sensing/lidar/concatenated/pointcloud|^/perception/object_recognition/detection/objects$|^/perception/object_recognition/tracking/objects$|^/perception/object_recognition/objects$|^/driving_log_replayer/.*|^/sensing/camera/.*",
+        RECORD_TOPIC_REGEX,
     )
 
     return launch.LaunchDescription(
@@ -80,5 +67,6 @@ def generate_launch_description() -> launch.LaunchDescription:
             player_normal,
             player_remap,
             recorder,
+            recorder_override,
         ],
     )

--- a/driving_log_replayer/launch/yabloc.launch.py
+++ b/driving_log_replayer/launch/yabloc.launch.py
@@ -48,8 +48,8 @@ def generate_launch_description() -> launch.LaunchDescription:
             autoware_launch,
             fitter_launch,
             evaluator_node,
+            player,
             recorder,
             recorder_override,
-            player,
         ],
     )

--- a/driving_log_replayer/launch/yabloc.launch.py
+++ b/driving_log_replayer/launch/yabloc.launch.py
@@ -16,6 +16,15 @@ import launch
 
 import driving_log_replayer.launch_common
 
+RECORD_TOPIC_REGEX = """^/clock$\
+|^/tf$\
+|^/diagnostics$\
+|^/localization/pose_estimator/pose$\
+|^/localization/kinematic_state$\
+|^/localization/util/downsample/pointcloud$\
+|^/localization/pose_estimator/points_aligned$
+"""
+
 
 def generate_launch_description() -> launch.LaunchDescription:
     launch_arguments = driving_log_replayer.launch_common.get_driving_log_replayer_common_argument()
@@ -27,17 +36,9 @@ def generate_launch_description() -> launch.LaunchDescription:
     rviz_node = driving_log_replayer.launch_common.get_rviz("localization.rviz")
     evaluator_node = driving_log_replayer.launch_common.get_evaluator_node("yabloc")
     player = driving_log_replayer.launch_common.get_player()
-    recorder = driving_log_replayer.launch_common.get_recorder(
+    recorder = driving_log_replayer.launch_common.get_regex_recorder(
         "localization.qos.yaml",
-        [
-            "/clock",
-            "/tf",
-            "/localization/pose_estimator/pose",
-            "/localization/kinematic_state",
-            "/localization/util/downsample/pointcloud",
-            "/localization/pose_estimator/points_aligned",
-            "/diagnostics",
-        ],
+        RECORD_TOPIC_REGEX,
     )
 
     return launch.LaunchDescription(

--- a/driving_log_replayer/launch/yabloc.launch.py
+++ b/driving_log_replayer/launch/yabloc.launch.py
@@ -36,7 +36,7 @@ def generate_launch_description() -> launch.LaunchDescription:
     rviz_node = driving_log_replayer.launch_common.get_rviz("localization.rviz")
     evaluator_node = driving_log_replayer.launch_common.get_evaluator_node("yabloc")
     player = driving_log_replayer.launch_common.get_player()
-    recorder = driving_log_replayer.launch_common.get_regex_recorder(
+    recorder, recorder_override = driving_log_replayer.launch_common.get_regex_recorders(
         "localization.qos.yaml",
         RECORD_TOPIC_REGEX,
     )
@@ -49,6 +49,7 @@ def generate_launch_description() -> launch.LaunchDescription:
             fitter_launch,
             evaluator_node,
             recorder,
+            recorder_override,
             player,
         ],
     )

--- a/driving_log_replayer/launch/yabloc.launch.py
+++ b/driving_log_replayer/launch/yabloc.launch.py
@@ -22,7 +22,7 @@ RECORD_TOPIC_REGEX = """^/clock$\
 |^/localization/pose_estimator/pose$\
 |^/localization/kinematic_state$\
 |^/localization/util/downsample/pointcloud$\
-|^/localization/pose_estimator/points_aligned$
+|^/localization/pose_estimator/points_aligned$\
 """
 
 

--- a/driving_log_replayer_cli/simulation/__init__.py
+++ b/driving_log_replayer_cli/simulation/__init__.py
@@ -34,7 +34,7 @@ def simulation() -> None:
     type=click.Choice(PERCEPTION_MODES, case_sensitive=False),
 )
 @click.option("--override_record_topics", "-o", default=False, type=bool)
-@click.option("--override_topics_regex", "-x", default="", type=str)
+@click.option("--override_topics_regex", "-x", default="/override_not_used", type=str)
 @click.option("--no-json", is_flag=True, help="Do not convert jsonl files to json")
 def run(
     profile: str,

--- a/driving_log_replayer_cli/simulation/__init__.py
+++ b/driving_log_replayer_cli/simulation/__init__.py
@@ -34,7 +34,7 @@ def simulation() -> None:
     type=click.Choice(PERCEPTION_MODES, case_sensitive=False),
 )
 @click.option("--override_record_topics", "-o", default=False, type=bool)
-@click.option("--override_topics_regex", "-x", default="/override_not_used", type=str)
+@click.option("--override_topics_regex", "-x", default="/override_unused", type=str)
 @click.option("--no-json", is_flag=True, help="Do not convert jsonl files to json")
 def run(
     profile: str,

--- a/driving_log_replayer_cli/simulation/__init__.py
+++ b/driving_log_replayer_cli/simulation/__init__.py
@@ -40,6 +40,8 @@ def run(
     delay: float,
     no_json: bool,  # noqa
     perception_mode: str,
+    override_record_topics: bool,  # noqa
+    override_topics_regex: str,
 ) -> None:
     config = load_config(profile)
     output_dir_by_time = Path(
@@ -54,6 +56,8 @@ def run(
         rate,
         delay,
         perception_mode,
+        override_record_topics,
+        override_topics_regex,
         not no_json,
     )
 

--- a/driving_log_replayer_cli/simulation/__init__.py
+++ b/driving_log_replayer_cli/simulation/__init__.py
@@ -33,6 +33,8 @@ def simulation() -> None:
     default="lidar",
     type=click.Choice(PERCEPTION_MODES, case_sensitive=False),
 )
+@click.option("--override_record_topics", "-o", default=False, type=bool)
+@click.option("--override_topics_regex", "-x", default="", type=str)
 @click.option("--no-json", is_flag=True, help="Do not convert jsonl files to json")
 def run(
     profile: str,

--- a/driving_log_replayer_cli/simulation/generate.py
+++ b/driving_log_replayer_cli/simulation/generate.py
@@ -26,6 +26,8 @@ class TestScriptGenerator:
         rate: float,
         delay: float,
         perception_mode: str,
+        override_recode_topics: bool,  # noqa
+        override_topics_regex: str,
     ) -> None:
         self.__data_directory = Path(data_directory)
         self.__output_directory = Path(output_directory)
@@ -34,6 +36,8 @@ class TestScriptGenerator:
         self.__rate = rate
         self.__delay = delay
         self.__perception_mode = perception_mode
+        self.__override_topics_regex = override_topics_regex
+        self.__override_recode_topics = override_recode_topics
         #  os.path.join(config.output_directory, datetime.datetime.now().strftime("%Y-%m%d-%H%M%S"))が渡ってくるので被ることはない
         self.__output_directory.mkdir(parents=True)
 
@@ -124,6 +128,8 @@ map_path:={essential_param.map_path} \
 vehicle_model:={essential_param.vehicle_model} \
 sensor_model:={essential_param.sensor_model} \
 vehicle_id:={essential_param.vehicle_id} \
+override_record_topics:={self.__override_recode_topics}
+override_topics_regex:={self.__override_topics_regex}
 rviz:=true\
 """
 

--- a/driving_log_replayer_cli/simulation/generate.py
+++ b/driving_log_replayer_cli/simulation/generate.py
@@ -128,8 +128,8 @@ map_path:={essential_param.map_path} \
 vehicle_model:={essential_param.vehicle_model} \
 sensor_model:={essential_param.sensor_model} \
 vehicle_id:={essential_param.vehicle_id} \
-override_record_topics:={self.__override_recode_topics}
-override_topics_regex:={self.__override_topics_regex}
+override_record_topics:={self.__override_recode_topics} \
+override_topics_regex:={self.__override_topics_regex} \
 rviz:=true\
 """
 

--- a/driving_log_replayer_cli/simulation/run.py
+++ b/driving_log_replayer_cli/simulation/run.py
@@ -17,6 +17,8 @@ class DrivingLogReplayerTestRunner:
         rate: float,
         delay: float,
         perception_mode: str,
+        override_record_topics: bool,  # noqa
+        override_topics_regex: str,
         output_json: bool,  # noqa
     ) -> None:
         self.__data_directory = expandvars(data_directory)
@@ -30,6 +32,8 @@ class DrivingLogReplayerTestRunner:
             rate,
             delay,
             perception_mode,
+            override_record_topics,
+            override_topics_regex,
         )
         is_executable = generator.run()
         if not is_executable:


### PR DESCRIPTION
## Types of PR

- [x] New Features

## Description

- override record topic using launch argument
- use `override_record_topics:=true override_topics_regex:=\^/clock\$\|\^/tf\$\|/sensing/lidar/concatenated/pointcloud`
  - notice: escape ^ $ | 

```shell
ros2 launch driving_log_replayer perception.launch.py perception_mode:=lidar scenario_path:=/home/hyt/data/perception/sample/scenario.yaml result_json_path:=/home/hyt/out/perception/2023-1114-162832/sample/sample_dataset/result.json play_rate:=0.5 play_delay:=10.0 input_bag:=/home/hyt/data/perception/sample/t4_dataset/sample_dataset/input_bag result_bag_path:=/home/hyt/out/perception/2023-1114-162832/sample/sample_dataset/result_bag map_path:=/home/hyt/map/oss vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit vehicle_id:=default override_record_topics:=True override_topics_regex:=\^/clock$\|\^/tf$\|/sensing/lidar/concatenated/pointcloud rviz:=true t4_dataset_path:=/home/hyt/data/perception/sample/t4_dataset/sample_dataset result_archive_path:=/home/hyt/out/perception/2023-1114-162832/sample/sample_dataset/result_archive sensing:=False
```

## How to review this PR

## Others
