### PR TITLE
feat: cli output console log

### DIFF
--- a/driving_log_replayer_cli/simulation/generate.py
+++ b/driving_log_replayer_cli/simulation/generate.py
@@ -8,23 +8,6 @@ import termcolor
 import yaml
 
 
-def run_with_log(cmd: list, log_path: Path) -> None:
-    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-    f = log_path.open("w", encoding="utf-8")
-
-    while True:
-        # バッファから1行読み込む.
-        line = proc.stdout.readline().decode("utf-8")
-        sys.stdout.write(line)
-        f.write(line)
-
-        # バッファが空 + プロセス終了.
-        if not line and proc.poll() is not None:
-            break
-
-    f.close()
-
-
 @dataclass(frozen=True)
 class AutowareEssentialParameter:
     map_path: Path = Path("/dlr_not_exist_path")

--- a/driving_log_replayer_cli/simulation/generate.py
+++ b/driving_log_replayer_cli/simulation/generate.py
@@ -2,7 +2,6 @@ from dataclasses import dataclass
 from os.path import expandvars
 from pathlib import Path
 import subprocess
-import sys
 
 import termcolor
 import yaml

--- a/driving_log_replayer_cli/simulation/generate.py
+++ b/driving_log_replayer_cli/simulation/generate.py
@@ -2,9 +2,27 @@ from dataclasses import dataclass
 from os.path import expandvars
 from pathlib import Path
 import subprocess
+import sys
 
 import termcolor
 import yaml
+
+
+def run_with_log(cmd: list, log_path: Path) -> None:
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    f = log_path.open("w", encoding="utf-8")
+
+    while True:
+        # バッファから1行読み込む.
+        line = proc.stdout.readline().decode("utf-8")
+        sys.stdout.write(line)
+        f.write(line)
+
+        # バッファが空 + プロセス終了.
+        if not line and proc.poll() is not None:
+            break
+
+    f.close()
 
 
 @dataclass(frozen=True)

--- a/driving_log_replayer_cli/simulation/run.py
+++ b/driving_log_replayer_cli/simulation/run.py
@@ -1,11 +1,26 @@
 from os.path import expandvars
+from pathlib import Path
 import subprocess
+import sys
 
 import termcolor
 
 from driving_log_replayer_cli.simulation.generate import TestScriptGenerator
 from driving_log_replayer_cli.simulation.result import convert
 from driving_log_replayer_cli.simulation.result import display
+
+
+def run_with_log(cmd: list, log_path: Path) -> None:
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    f = log_path.open("w", encoding="utf-8")
+
+    while True:
+        line = proc.stdout.readline().decode("utf-8")
+        sys.stdout.write(line)
+        f.write(line)
+        if not line and proc.poll() is not None:
+            break
+    f.close()
 
 
 class DrivingLogReplayerTestRunner:
@@ -40,7 +55,7 @@ class DrivingLogReplayerTestRunner:
             print("aborted.")  # noqa
             return
         cmd = ["/bin/bash", generator.script_path.as_posix()]
-        subprocess.run(cmd, check=False)
+        run_with_log(cmd, Path(self.__output_directory, "console.log"))
         if output_json:
             convert(self.__output_directory)
         termcolor.cprint("<< show test result >>", "green")


### PR DESCRIPTION
## Types of PR

- [x] New Features

## Description

- Save the log displayed in the console as a file in the output directory

## How to review this PR

1. checkout `feat/cli-output-console-log` 
2. install cli `pipx install . -f`
3. run simulation `dlr simulation run`
4. `console.log` is saved in your output directory

like blow image

<img width="468" alt="2023-12-04_15-22" src="https://github.com/tier4/driving_log_replayer/assets/16977736/fa6c0c1b-9545-449b-9a66-c6259148e426">



## Others
