### PR TITLE
fix: set-output command

### DIFF
--- a/.github/workflows/colcon-test.yaml
+++ b/.github/workflows/colcon-test.yaml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  test_environment:
+  build-and-test:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -37,7 +37,7 @@ jobs:
       - name: Search packages in this repository
         id: list_packages
         run: |
-          echo ::set-output name=package_list::$(colcon list --names-only)
+          echo package_list=$(colcon list --names-only | sed -e ':loop; N; $!b loop; s/\n/ /g') >> $GITHUB_OUTPUT
 
       - name: Setup ROS environment
         uses: ros-tooling/setup-ros@0.7.0


### PR DESCRIPTION
## Types of PR

- [x] Upgrade of existing features

## Description

- remove deprecating command
- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## How to review this PR

## Others
