### PR TITLE
fix: overwrite pose_source and twist_source

### DIFF
--- a/driving_log_replayer/driving_log_replayer/launch_common.py
+++ b/driving_log_replayer/driving_log_replayer/launch_common.py
@@ -105,8 +105,8 @@ def get_autoware_launch(
     planning: str = "false",
     control: str = "false",
     scenario_simulation: str = "false",
-    pose_source: str = "ndt",
-    twist_source: str = "gyro_odom",
+    pose_source: str | None = None,
+    twist_source: str | None = None,
     perception_mode: str | None = None,
 ) -> launch.actions.IncludeLaunchDescription:
     # autoware launch
@@ -128,9 +128,11 @@ def get_autoware_launch(
         "control": control,
         "rviz": "false",
         "scenario_simulation": scenario_simulation,
-        "pose_source": pose_source,
-        "twist_source": twist_source,
     }
+    if isinstance(pose_source, str):
+        launch_args["pose_source"] = pose_source
+    if isinstance(twist_source, str):
+        launch_args["twist_source"] = twist_source
     if isinstance(perception_mode, str):
         launch_args["perception_mode"] = perception_mode
     return launch.actions.IncludeLaunchDescription(

--- a/driving_log_replayer/launch/ar_tag_based_localizer.launch.py
+++ b/driving_log_replayer/launch/ar_tag_based_localizer.launch.py
@@ -29,6 +29,7 @@ def generate_launch_description() -> launch.LaunchDescription:
     autoware_launch = cmn.get_autoware_launch(
         perception="false",
         pose_source="artag",
+        twist_source="gyro_odom",
     )
     rviz_node = cmn.get_rviz("localization.rviz")
     evaluator_node = cmn.get_evaluator_node("ar_tag_based_localizer")

--- a/driving_log_replayer/launch/localization.launch.py
+++ b/driving_log_replayer/launch/localization.launch.py
@@ -31,7 +31,11 @@ RECORD_TOPIC_REGEX = """^/clock$\
 def generate_launch_description() -> launch.LaunchDescription:
     launch_arguments = cmn.get_launch_arguments()
     fitter_launch = cmn.get_map_height_fitter(launch_service="true")
-    autoware_launch = cmn.get_autoware_launch(perception="false")
+    autoware_launch = cmn.get_autoware_launch(
+        perception="false",
+        pose_source="ndt",
+        twist_source="gyro_odom",
+    )
     rviz_node = cmn.get_rviz("localization.rviz")
     evaluator_node = cmn.get_evaluator_node("localization")
     player = cmn.get_player()

--- a/driving_log_replayer/launch/yabloc.launch.py
+++ b/driving_log_replayer/launch/yabloc.launch.py
@@ -32,6 +32,7 @@ def generate_launch_description() -> launch.LaunchDescription:
     autoware_launch = cmn.get_autoware_launch(
         perception="false",
         pose_source="yabloc",
+        twist_source="gyro_odom",
     )
     rviz_node = cmn.get_rviz("localization.rviz")
     evaluator_node = cmn.get_evaluator_node("yabloc")


### PR DESCRIPTION
## Types of PR

- [x] Bugfix

## Description

The implicitly passed arguments `pose_source` and `twist_source` are overwritten in the `get_autoware_launch` function's given default values.
Currently, there is no problem because the default value specified in `get_autoware_launch` matches the default value written in launch.
However, if the default value in launch is changed, unintentional overwriting will occur.
To prevent unintentional overwriting, do not specify `pose_source` and `twist_source` as arguments to autoware.launch unless explicitly specified.

## How to review this PR

## Reference

- https://github.com/autowarefoundation/autoware.universe/issues/2695