### PR TITLE
feat: add maph criteria

### DIFF
--- a/driving_log_replayer/driving_log_replayer/criteria/perception.py
+++ b/driving_log_replayer/driving_log_replayer/criteria/perception.py
@@ -19,7 +19,7 @@ from abc import ABC
 from abc import abstractmethod
 from enum import Enum
 from numbers import Number
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING
 
 from perception_eval.common.evaluation_task import EvaluationTask
 from perception_eval.evaluation.matching import MatchingMode
@@ -47,9 +47,8 @@ class SuccessFail(Enum):
         """
         return self == SuccessFail.SUCCESS
 
-    def __and__(self, other: SuccessFail):
-        if isinstance(other, SuccessFail):
-            return SuccessFail.SUCCESS if self.is_success() and other.is_success() else SuccessFail.FAIL
+    def __and__(self, other: SuccessFail) -> SuccessFail:
+        return SuccessFail.SUCCESS if self.is_success() and other.is_success() else SuccessFail.FAIL
 
 
 class CriteriaLevel(Enum):
@@ -282,7 +281,7 @@ class PerceptionCriteria:
 
     Args:
     ----
-        methods (str | List[str] | CriteriaMethod | List[CriteriaMethod] | None): List of criteria method instances or names.
+        methods (str | list[str] | CriteriaMethod | list[CriteriaMethod] | None): List of criteria method instances or names.
             If None, `CriteriaMethod.NUM_TP` is used. Defaults to None.
         level (str | Number | CriteriaLevel | None): Criteria level instance or name.
             If None, `CriteriaLevel.Easy` is used. Defaults to None.
@@ -290,7 +289,7 @@ class PerceptionCriteria:
 
     def __init__(
         self,
-        methods: str | List[str] | CriteriaMethod | List[CriteriaMethod] | None = None,
+        methods: str | list[str] | CriteriaMethod | list[CriteriaMethod] | None = None,
         level: str | Number | CriteriaLevel | None = None,
     ) -> None:
         methods = [CriteriaMethod.NUM_TP] if methods is None else self.load_methods(methods)
@@ -305,25 +304,28 @@ class PerceptionCriteria:
             elif method == CriteriaMethod.METRICS_SCORE_MAPH:
                 self.methods.append(MetricsScoreMAPH(level))
             else:
-                raise NotImplementedError(f"Unsupported method: {method}")
+                error_msg: str = f"Unsupported method: {method}"
+                raise NotImplementedError(error_msg)
 
     @staticmethod
-    def load_methods(methods_input: str | List[str] | CriteriaMethod | List[CriteriaMethod]) -> List[CriteriaMethod]:
+    def load_methods(
+        methods_input: str | list[str] | CriteriaMethod | list[CriteriaMethod],
+    ) -> list[CriteriaMethod]:
         """
         Load `CriteriaMethod` enum.
 
         Args:
         ----
-            methods (str | List[str] | CriteriaMethod | List[CriteriaMethod]): Criteria method instance or name.
+            methods (str | list[str] | CriteriaMethod | list[CriteriaMethod]): Criteria method instance or name.
 
         Returns:
         -------
             List[CriteriaMethod]: Instance.
         """
         if isinstance(methods_input, str):
-            loaded_methods: List[CriteriaMethod] = [CriteriaMethod.from_str(methods_input)]
+            loaded_methods = [CriteriaMethod.from_str(methods_input)]
         elif isinstance(methods_input, CriteriaMethod):
-            loaded_methods: List[CriteriaMethod] = [methods_input]
+            loaded_methods = [methods_input]
         elif isinstance(methods_input, list):
             if isinstance(methods_input[0], str):
                 loaded_methods = [CriteriaMethod.from_str(method) for method in methods_input]

--- a/driving_log_replayer/driving_log_replayer/criteria/perception.py
+++ b/driving_log_replayer/driving_log_replayer/criteria/perception.py
@@ -150,7 +150,6 @@ class CriteriaMethod(Enum):
         -------
             CriteriaMode: `CriteriaMode` instance.
         """
-        print("HOGE!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!, ", value)
         name: str = value.upper()
         assert name in cls.__members__, "value must be NUM_TP, METRICS_SCORE, or METRICS_SCORE_MAPH"
         return cls.__members__[name]

--- a/driving_log_replayer/driving_log_replayer/criteria/perception.py
+++ b/driving_log_replayer/driving_log_replayer/criteria/perception.py
@@ -15,7 +15,8 @@
 
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
+from abc import ABC
+from abc import abstractmethod
 from enum import Enum
 from numbers import Number
 from typing import TYPE_CHECKING, List

--- a/driving_log_replayer/driving_log_replayer/criteria/perception.py
+++ b/driving_log_replayer/driving_log_replayer/criteria/perception.py
@@ -302,7 +302,7 @@ class PerceptionCriteria:
         levels = [CriteriaLevel.EASY] if levels is None else self.load_levels(levels)
 
         assert len(methods) == len(
-            levels
+            levels,
         ), f"Number of CriteriaMethod and CriteriaLevel must be same. Current methods: {methods}, levels: {levels}"
 
         self.methods = []

--- a/driving_log_replayer/driving_log_replayer/criteria/perception.py
+++ b/driving_log_replayer/driving_log_replayer/criteria/perception.py
@@ -15,11 +15,10 @@
 
 from __future__ import annotations
 
-from abc import ABC
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from enum import Enum
 from numbers import Number
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, List
 
 from perception_eval.common.evaluation_task import EvaluationTask
 from perception_eval.evaluation.matching import MatchingMode
@@ -46,6 +45,10 @@ class SuccessFail(Enum):
             bool: Success or fail.
         """
         return self == SuccessFail.SUCCESS
+
+    def __and__(self, other: SuccessFail):
+        if isinstance(other, SuccessFail):
+            return SuccessFail.SUCCESS if self.is_success() and other.is_success() else SuccessFail.FAIL
 
 
 class CriteriaLevel(Enum):
@@ -127,10 +130,12 @@ class CriteriaMethod(Enum):
 
     - NUM_TP: Number of TP (or TN).
     - METRICS_SCORE: Accuracy score for classification, otherwise mAP score is used.
+    - METRICS_SCORE_MAPH: mAPH score.
     """
 
     NUM_TP = "num_tp"
     METRICS_SCORE = "metrics_score"
+    METRICS_SCORE_MAPH = "metrics_score_maph"
 
     @classmethod
     def from_str(cls, value: str) -> CriteriaMethod:
@@ -145,8 +150,9 @@ class CriteriaMethod(Enum):
         -------
             CriteriaMode: `CriteriaMode` instance.
         """
+        print("HOGE!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!, ", value)
         name: str = value.upper()
-        assert name in cls.__members__, "value must be NUM_TP or METRICS_SCORE"
+        assert name in cls.__members__, "value must be NUM_TP, METRICS_SCORE, or METRICS_SCORE_MAPH"
         return cls.__members__[name]
 
 
@@ -252,13 +258,31 @@ class MetricsScore(CriteriaMethodImpl):
         return 100.0 * sum(scores) / len(scores) if len(scores) != 0 else 0.0
 
 
+class MetricsScoreMAPH(CriteriaMethodImpl):
+    name = CriteriaMethod.METRICS_SCORE_MAPH
+
+    def __init__(self, level: CriteriaLevel) -> None:
+        super().__init__(level)
+
+    @staticmethod
+    def calculate_score(frame: PerceptionFrameResult) -> float:
+        assert frame.metrics_score.evaluation_task.is_3d(), "Evaluation task must be 3D for MAPH."
+        scores = [
+            map_.maph
+            for map_ in frame.metrics_score.maps
+            if map_.maph != float("inf") and map_.matching_mode == MatchingMode.CENTERDISTANCE
+        ]
+
+        return 100.0 * sum(scores) / len(scores) if len(scores) != 0 else 0.0
+
+
 class PerceptionCriteria:
     """
     Criteria interface for perception evaluation.
 
     Args:
     ----
-        method (str | CriteriaMethod | None): Criteria method instance or name.
+        methods (str | List[str] | CriteriaMethod | List[CriteriaMethod] | None): List of criteria method instances or names.
             If None, `CriteriaMethod.NUM_TP` is used. Defaults to None.
         level (str | Number | CriteriaLevel | None): Criteria level instance or name.
             If None, `CriteriaLevel.Easy` is used. Defaults to None.
@@ -266,34 +290,49 @@ class PerceptionCriteria:
 
     def __init__(
         self,
-        method: str | CriteriaMethod | None = None,
+        methods: str | List[str] | CriteriaMethod | List[CriteriaMethod] | None = None,
         level: str | Number | CriteriaLevel | None = None,
     ) -> None:
-        method = CriteriaMethod.NUM_TP if method is None else self.load_method(method)
+        methods = [CriteriaMethod.NUM_TP] if methods is None else self.load_methods(methods)
         level = CriteriaLevel.EASY if level is None else self.load_level(level)
 
-        if method == CriteriaMethod.NUM_TP:
-            self.method = NumTP(level)
-        elif method == CriteriaMethod.METRICS_SCORE:
-            self.method = MetricsScore(level)
+        self.methods = []
+        for method in methods:
+            if method == CriteriaMethod.NUM_TP:
+                self.methods.append(NumTP(level))
+            elif method == CriteriaMethod.METRICS_SCORE:
+                self.methods.append(MetricsScore(level))
+            elif method == CriteriaMethod.METRICS_SCORE_MAPH:
+                self.methods.append(MetricsScoreMAPH(level))
+            else:
+                raise NotImplementedError(f"Unsupported method: {method}")
 
     @staticmethod
-    def load_method(method: str | CriteriaMethod) -> CriteriaMethod:
+    def load_methods(methods_input: str | List[str] | CriteriaMethod | List[CriteriaMethod]) -> List[CriteriaMethod]:
         """
         Load `CriteriaMethod` enum.
 
         Args:
         ----
-            method (str | CriteriaMethod): Criteria method instance or name.
+            methods (str | List[str] | CriteriaMethod | List[CriteriaMethod]): Criteria method instance or name.
 
         Returns:
         -------
-            CriteriaMethod: Instance.
+            List[CriteriaMethod]: Instance.
         """
-        if isinstance(method, str):
-            method: CriteriaMethod = CriteriaMethod.from_str(method)
-        assert isinstance(method, CriteriaMethod), f"Invalid type of method: {type(method)}"
-        return method
+        if isinstance(methods_input, str):
+            loaded_methods: List[CriteriaMethod] = [CriteriaMethod.from_str(methods_input)]
+        elif isinstance(methods_input, CriteriaMethod):
+            loaded_methods: List[CriteriaMethod] = [methods_input]
+        elif isinstance(methods_input, list):
+            if isinstance(methods_input[0], str):
+                loaded_methods = [CriteriaMethod.from_str(method) for method in methods_input]
+            elif isinstance(methods_input[0], CriteriaMethod):
+                loaded_methods = methods_input
+
+        for method in loaded_methods:
+            assert isinstance(method, CriteriaMethod), f"Invalid type of method: {type(method)}"
+        return loaded_methods
 
     @staticmethod
     def load_level(level: str | Number | CriteriaLevel) -> CriteriaLevel:
@@ -327,4 +366,7 @@ class PerceptionCriteria:
         -------
             SuccessFail: Success/Fail result.
         """
-        return self.method.get_result(frame)
+        result: SuccessFail = SuccessFail.SUCCESS
+        for method in self.methods:
+            result &= method.get_result(frame)
+        return result

--- a/driving_log_replayer/driving_log_replayer/criteria/perception.py
+++ b/driving_log_replayer/driving_log_replayer/criteria/perception.py
@@ -290,12 +290,20 @@ class PerceptionCriteria:
     def __init__(
         self,
         methods: str | list[str] | CriteriaMethod | list[CriteriaMethod] | None = None,
-        levels: str | list[str] | Number | list[Number] | CriteriaLevel | list[CriteriaLevel] | None = None,
+        levels: str
+        | list[str]
+        | Number
+        | list[Number]
+        | CriteriaLevel
+        | list[CriteriaLevel]
+        | None = None,
     ) -> None:
         methods = [CriteriaMethod.NUM_TP] if methods is None else self.load_methods(methods)
         levels = [CriteriaLevel.EASY] if levels is None else self.load_levels(levels)
 
-        assert len(methods) == len(levels), f"Number of CriteriaMethod and CriteriaLevel must be same. Current methods: {methods}, levels: {levels}"
+        assert len(methods) == len(
+            levels
+        ), f"Number of CriteriaMethod and CriteriaLevel must be same. Current methods: {methods}, levels: {levels}"
 
         self.methods = []
         for method, level in zip(methods, levels):
@@ -339,7 +347,9 @@ class PerceptionCriteria:
         return loaded_methods
 
     @staticmethod
-    def load_levels(levels_input: str | list[str] | Number | list[Number] | CriteriaLevel | list[CriteriaLevel]) -> list[CriteriaLevel]:
+    def load_levels(
+        levels_input: str | list[str] | Number | list[Number] | CriteriaLevel | list[CriteriaLevel],
+    ) -> list[CriteriaLevel]:
         """
         Load `CriteriaLevel`.
 

--- a/driving_log_replayer/driving_log_replayer/criteria/perception.py
+++ b/driving_log_replayer/driving_log_replayer/criteria/perception.py
@@ -320,7 +320,7 @@ class PerceptionCriteria:
 
         Returns:
         -------
-            List[CriteriaMethod]: Instance.
+            list[CriteriaMethod]: Instance.
         """
         if isinstance(methods_input, str):
             loaded_methods = [CriteriaMethod.from_str(methods_input)]

--- a/driving_log_replayer/driving_log_replayer/perception.py
+++ b/driving_log_replayer/driving_log_replayer/perception.py
@@ -13,17 +13,20 @@
 # limitations under the License.
 
 from dataclasses import dataclass
-from typing import List
 
-import driving_log_replayer.perception_eval_conversions as eval_conversions
-from driving_log_replayer.criteria import PerceptionCriteria
-from driving_log_replayer.result import EvaluationItem, ResultBase
-from driving_log_replayer.scenario import Scenario, number
 from perception_eval.evaluation import PerceptionFrameResult
 from pydantic import BaseModel
-from std_msgs.msg import ColorRGBA, Header
+from std_msgs.msg import ColorRGBA
+from std_msgs.msg import Header
 from typing_extensions import Literal
 from visualization_msgs.msg import MarkerArray
+
+from driving_log_replayer.criteria import PerceptionCriteria
+import driving_log_replayer.perception_eval_conversions as eval_conversions
+from driving_log_replayer.result import EvaluationItem
+from driving_log_replayer.result import ResultBase
+from driving_log_replayer.scenario import number
+from driving_log_replayer.scenario import Scenario
 
 
 class Conditions(BaseModel):

--- a/driving_log_replayer/driving_log_replayer/perception.py
+++ b/driving_log_replayer/driving_log_replayer/perception.py
@@ -34,7 +34,9 @@ class Conditions(BaseModel):
     CriteriaMethod: Literal["num_tp", "metrics_score", "metrics_score_maph"] | list[
         str
     ] | None = None
-    CriteriaLevel: Literal["perfect", "hard", "normal", "easy"] | list[str] | number | list[number] | None = None
+    CriteriaLevel: Literal["perfect", "hard", "normal", "easy"] | list[str] | number | list[
+        number
+    ] | None = None
 
 
 class Evaluation(BaseModel):

--- a/driving_log_replayer/driving_log_replayer/perception.py
+++ b/driving_log_replayer/driving_log_replayer/perception.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 from dataclasses import dataclass
+from typing import List
 
 from perception_eval.evaluation import PerceptionFrameResult
 from pydantic import BaseModel
 from std_msgs.msg import ColorRGBA
 from std_msgs.msg import Header
 from typing_extensions import Literal
-from typing import List
 from visualization_msgs.msg import MarkerArray
 
 from driving_log_replayer.criteria import PerceptionCriteria
@@ -32,7 +32,9 @@ from driving_log_replayer.scenario import Scenario
 
 class Conditions(BaseModel):
     PassRate: number
-    CriteriaMethod: Literal["num_tp", "metrics_score", "metrics_score_maph"] | List[str] | None = None
+    CriteriaMethod: Literal["num_tp", "metrics_score", "metrics_score_maph"] | List[
+        str
+    ] | None = None
     CriteriaLevel: Literal["perfect", "hard", "normal", "easy"] | number | None = None
 
 

--- a/driving_log_replayer/driving_log_replayer/perception.py
+++ b/driving_log_replayer/driving_log_replayer/perception.py
@@ -13,25 +13,22 @@
 # limitations under the License.
 
 from dataclasses import dataclass
+from typing import List
 
+import driving_log_replayer.perception_eval_conversions as eval_conversions
+from driving_log_replayer.criteria import PerceptionCriteria
+from driving_log_replayer.result import EvaluationItem, ResultBase
+from driving_log_replayer.scenario import Scenario, number
 from perception_eval.evaluation import PerceptionFrameResult
 from pydantic import BaseModel
-from std_msgs.msg import ColorRGBA
-from std_msgs.msg import Header
+from std_msgs.msg import ColorRGBA, Header
 from typing_extensions import Literal
 from visualization_msgs.msg import MarkerArray
-
-from driving_log_replayer.criteria import PerceptionCriteria
-import driving_log_replayer.perception_eval_conversions as eval_conversions
-from driving_log_replayer.result import EvaluationItem
-from driving_log_replayer.result import ResultBase
-from driving_log_replayer.scenario import number
-from driving_log_replayer.scenario import Scenario
 
 
 class Conditions(BaseModel):
     PassRate: number
-    CriteriaMethod: Literal["num_tp", "metrics_score"] | None = None
+    CriteriaMethod: Literal["num_tp", "metrics_score", "metrics_score_maph"] | List[str] | None = None
     CriteriaLevel: Literal["perfect", "hard", "normal", "easy"] | number | None = None
 
 
@@ -55,7 +52,7 @@ class Perception(EvaluationItem):
 
     def __post_init__(self) -> None:
         self.criteria: PerceptionCriteria = PerceptionCriteria(
-            method=self.condition.CriteriaMethod,
+            methods=self.condition.CriteriaMethod,
             level=self.condition.CriteriaLevel,
         )
 

--- a/driving_log_replayer/driving_log_replayer/perception.py
+++ b/driving_log_replayer/driving_log_replayer/perception.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from dataclasses import dataclass
-from typing import List
 
 from perception_eval.evaluation import PerceptionFrameResult
 from pydantic import BaseModel
@@ -32,7 +31,7 @@ from driving_log_replayer.scenario import Scenario
 
 class Conditions(BaseModel):
     PassRate: number
-    CriteriaMethod: Literal["num_tp", "metrics_score", "metrics_score_maph"] | List[
+    CriteriaMethod: Literal["num_tp", "metrics_score", "metrics_score_maph"] | list[
         str
     ] | None = None
     CriteriaLevel: Literal["perfect", "hard", "normal", "easy"] | number | None = None

--- a/driving_log_replayer/driving_log_replayer/perception.py
+++ b/driving_log_replayer/driving_log_replayer/perception.py
@@ -34,7 +34,7 @@ class Conditions(BaseModel):
     CriteriaMethod: Literal["num_tp", "metrics_score", "metrics_score_maph"] | list[
         str
     ] | None = None
-    CriteriaLevel: Literal["perfect", "hard", "normal", "easy"] | number | None = None
+    CriteriaLevel: Literal["perfect", "hard", "normal", "easy"] | list[str] | number | list[number] | None = None
 
 
 class Evaluation(BaseModel):
@@ -58,7 +58,7 @@ class Perception(EvaluationItem):
     def __post_init__(self) -> None:
         self.criteria: PerceptionCriteria = PerceptionCriteria(
             methods=self.condition.CriteriaMethod,
-            level=self.condition.CriteriaLevel,
+            levels=self.condition.CriteriaLevel,
         )
 
     def set_frame(

--- a/driving_log_replayer/driving_log_replayer/perception.py
+++ b/driving_log_replayer/driving_log_replayer/perception.py
@@ -19,6 +19,7 @@ from pydantic import BaseModel
 from std_msgs.msg import ColorRGBA
 from std_msgs.msg import Header
 from typing_extensions import Literal
+from typing import List
 from visualization_msgs.msg import MarkerArray
 
 from driving_log_replayer.criteria import PerceptionCriteria

--- a/driving_log_replayer/driving_log_replayer/perception_2d.py
+++ b/driving_log_replayer/driving_log_replayer/perception_2d.py
@@ -14,12 +14,15 @@
 
 from dataclasses import dataclass
 
-from driving_log_replayer.criteria import PerceptionCriteria
-from driving_log_replayer.result import EvaluationItem, ResultBase
-from driving_log_replayer.scenario import Scenario, number
 from perception_eval.evaluation import PerceptionFrameResult
 from pydantic import BaseModel
 from typing_extensions import Literal
+
+from driving_log_replayer.criteria import PerceptionCriteria
+from driving_log_replayer.result import EvaluationItem
+from driving_log_replayer.result import ResultBase
+from driving_log_replayer.scenario import number
+from driving_log_replayer.scenario import Scenario
 
 
 class Conditions(BaseModel):

--- a/driving_log_replayer/driving_log_replayer/perception_2d.py
+++ b/driving_log_replayer/driving_log_replayer/perception_2d.py
@@ -52,7 +52,7 @@ class Perception(EvaluationItem):
         self.condition: Conditions
         self.criteria: PerceptionCriteria = PerceptionCriteria(
             methods=self.condition.CriteriaMethod,
-            level=self.condition.CriteriaLevel,
+            levels=self.condition.CriteriaLevel,
         )
 
     def set_frame(

--- a/driving_log_replayer/driving_log_replayer/perception_2d.py
+++ b/driving_log_replayer/driving_log_replayer/perception_2d.py
@@ -14,15 +14,12 @@
 
 from dataclasses import dataclass
 
+from driving_log_replayer.criteria import PerceptionCriteria
+from driving_log_replayer.result import EvaluationItem, ResultBase
+from driving_log_replayer.scenario import Scenario, number
 from perception_eval.evaluation import PerceptionFrameResult
 from pydantic import BaseModel
 from typing_extensions import Literal
-
-from driving_log_replayer.criteria import PerceptionCriteria
-from driving_log_replayer.result import EvaluationItem
-from driving_log_replayer.result import ResultBase
-from driving_log_replayer.scenario import number
-from driving_log_replayer.scenario import Scenario
 
 
 class Conditions(BaseModel):
@@ -51,7 +48,7 @@ class Perception(EvaluationItem):
     def __post_init__(self) -> None:
         self.condition: Conditions
         self.criteria: PerceptionCriteria = PerceptionCriteria(
-            method=self.condition.CriteriaMethod,
+            methods=self.condition.CriteriaMethod,
             level=self.condition.CriteriaLevel,
         )
 

--- a/driving_log_replayer/driving_log_replayer/traffic_light.py
+++ b/driving_log_replayer/driving_log_replayer/traffic_light.py
@@ -53,7 +53,7 @@ class Perception(EvaluationItem):
         self.condition: Conditions
         self.criteria: PerceptionCriteria = PerceptionCriteria(
             methods=self.condition.CriteriaMethod,
-            level=self.condition.CriteriaLevel,
+            levels=self.condition.CriteriaLevel,
         )
 
     def set_frame(self, frame: PerceptionFrameResult, skip: int, map_to_baselink: dict) -> dict:

--- a/driving_log_replayer/driving_log_replayer/traffic_light.py
+++ b/driving_log_replayer/driving_log_replayer/traffic_light.py
@@ -14,12 +14,15 @@
 
 from dataclasses import dataclass
 
-from driving_log_replayer.criteria import PerceptionCriteria
-from driving_log_replayer.result import EvaluationItem, ResultBase
-from driving_log_replayer.scenario import Scenario, number
 from perception_eval.evaluation import PerceptionFrameResult
 from pydantic import BaseModel
 from typing_extensions import Literal
+
+from driving_log_replayer.criteria import PerceptionCriteria
+from driving_log_replayer.result import EvaluationItem
+from driving_log_replayer.result import ResultBase
+from driving_log_replayer.scenario import number
+from driving_log_replayer.scenario import Scenario
 
 
 class Conditions(BaseModel):

--- a/driving_log_replayer/driving_log_replayer/traffic_light.py
+++ b/driving_log_replayer/driving_log_replayer/traffic_light.py
@@ -14,15 +14,12 @@
 
 from dataclasses import dataclass
 
+from driving_log_replayer.criteria import PerceptionCriteria
+from driving_log_replayer.result import EvaluationItem, ResultBase
+from driving_log_replayer.scenario import Scenario, number
 from perception_eval.evaluation import PerceptionFrameResult
 from pydantic import BaseModel
 from typing_extensions import Literal
-
-from driving_log_replayer.criteria import PerceptionCriteria
-from driving_log_replayer.result import EvaluationItem
-from driving_log_replayer.result import ResultBase
-from driving_log_replayer.scenario import number
-from driving_log_replayer.scenario import Scenario
 
 
 class Conditions(BaseModel):
@@ -52,7 +49,7 @@ class Perception(EvaluationItem):
     def __post_init__(self) -> None:
         self.condition: Conditions
         self.criteria: PerceptionCriteria = PerceptionCriteria(
-            method=self.condition.CriteriaMethod,
+            methods=self.condition.CriteriaMethod,
             level=self.condition.CriteriaLevel,
         )
 

--- a/driving_log_replayer/test/unittest/test_perception.py
+++ b/driving_log_replayer/test/unittest/test_perception.py
@@ -50,7 +50,7 @@ def test_scenario_criteria_custom_level() -> None:
         "scenario.criteria.custom.yaml",
     )
     assert scenario.Evaluation.Conditions.CriteriaMethod == ["metrics_score", "metrics_score_maph"]
-    assert scenario.Evaluation.Conditions.CriteriaLevel == 10.0  # noqa
+    assert scenario.Evaluation.Conditions.CriteriaLevel == [10.0, 10.0]
 
 
 @pytest.fixture()

--- a/driving_log_replayer/test/unittest/test_perception.py
+++ b/driving_log_replayer/test/unittest/test_perception.py
@@ -13,24 +13,28 @@
 # limitations under the License.
 from typing import Callable
 
-import pytest
-from driving_log_replayer.perception import (Conditions, Perception,
-                                             PerceptionScenario)
-from driving_log_replayer.scenario import load_sample_scenario
 from perception_eval.common import DynamicObject
 from perception_eval.common.dataset import FrameGroundTruth
 from perception_eval.common.evaluation_task import EvaluationTask
-from perception_eval.common.label import AutowareLabel, Label
+from perception_eval.common.label import AutowareLabel
+from perception_eval.common.label import Label
 from perception_eval.common.schema import FrameID
-from perception_eval.common.shape import Shape, ShapeType
+from perception_eval.common.shape import Shape
+from perception_eval.common.shape import ShapeType
 from perception_eval.config import PerceptionEvaluationConfig
-from perception_eval.evaluation import (DynamicObjectWithPerceptionResult,
-                                        PerceptionFrameResult)
+from perception_eval.evaluation import DynamicObjectWithPerceptionResult
+from perception_eval.evaluation import PerceptionFrameResult
 from perception_eval.evaluation.metrics import MetricsScoreConfig
-from perception_eval.evaluation.result.perception_frame_config import (
-    CriticalObjectFilterConfig, PerceptionPassFailConfig)
+from perception_eval.evaluation.result.perception_frame_config import CriticalObjectFilterConfig
+from perception_eval.evaluation.result.perception_frame_config import PerceptionPassFailConfig
 from pyquaternion import Quaternion
+import pytest
 from std_msgs.msg import Header
+
+from driving_log_replayer.perception import Conditions
+from driving_log_replayer.perception import Perception
+from driving_log_replayer.perception import PerceptionScenario
+from driving_log_replayer.scenario import load_sample_scenario
 
 
 def test_scenario() -> None:

--- a/driving_log_replayer/test/unittest/test_perception.py
+++ b/driving_log_replayer/test/unittest/test_perception.py
@@ -13,28 +13,24 @@
 # limitations under the License.
 from typing import Callable
 
+import pytest
+from driving_log_replayer.perception import (Conditions, Perception,
+                                             PerceptionScenario)
+from driving_log_replayer.scenario import load_sample_scenario
 from perception_eval.common import DynamicObject
 from perception_eval.common.dataset import FrameGroundTruth
 from perception_eval.common.evaluation_task import EvaluationTask
-from perception_eval.common.label import AutowareLabel
-from perception_eval.common.label import Label
+from perception_eval.common.label import AutowareLabel, Label
 from perception_eval.common.schema import FrameID
-from perception_eval.common.shape import Shape
-from perception_eval.common.shape import ShapeType
+from perception_eval.common.shape import Shape, ShapeType
 from perception_eval.config import PerceptionEvaluationConfig
-from perception_eval.evaluation import DynamicObjectWithPerceptionResult
-from perception_eval.evaluation import PerceptionFrameResult
+from perception_eval.evaluation import (DynamicObjectWithPerceptionResult,
+                                        PerceptionFrameResult)
 from perception_eval.evaluation.metrics import MetricsScoreConfig
-from perception_eval.evaluation.result.perception_frame_config import CriticalObjectFilterConfig
-from perception_eval.evaluation.result.perception_frame_config import PerceptionPassFailConfig
+from perception_eval.evaluation.result.perception_frame_config import (
+    CriticalObjectFilterConfig, PerceptionPassFailConfig)
 from pyquaternion import Quaternion
-import pytest
 from std_msgs.msg import Header
-
-from driving_log_replayer.perception import Conditions
-from driving_log_replayer.perception import Perception
-from driving_log_replayer.perception import PerceptionScenario
-from driving_log_replayer.scenario import load_sample_scenario
 
 
 def test_scenario() -> None:
@@ -49,7 +45,7 @@ def test_scenario_criteria_custom_level() -> None:
         PerceptionScenario,
         "scenario.criteria.custom.yaml",
     )
-    assert scenario.Evaluation.Conditions.CriteriaMethod == "metrics_score"
+    assert scenario.Evaluation.Conditions.CriteriaMethod == ["metrics_score", "metrics_score_maph"]
     assert scenario.Evaluation.Conditions.CriteriaLevel == 10.0  # noqa
 
 

--- a/sample/perception/scenario.criteria.custom.yaml
+++ b/sample/perception/scenario.criteria.custom.yaml
@@ -13,7 +13,7 @@ Evaluation:
         LocalMapPath: $HOME/autoware_map/sample-map-planning # Specify LocalMapPath for each data set.
   Conditions:
     PassRate: 95.0 # How much (%) of the evaluation attempts are considered successful.
-    CriteriaMethod: metrics_score # Method name of criteria (num_tp/metrics_score)
+    CriteriaMethod: [metrics_score, metrics_score_maph] # Method name of criteria (num_tp/metrics_score)
     CriteriaLevel: 10.0 # Level of criteria (perfect/hard/normal/easy, or custom value 0.0-100.0)
   PerceptionEvaluationConfig:
     evaluation_config_dict:

--- a/sample/perception/scenario.criteria.custom.yaml
+++ b/sample/perception/scenario.criteria.custom.yaml
@@ -14,7 +14,7 @@ Evaluation:
   Conditions:
     PassRate: 95.0 # How much (%) of the evaluation attempts are considered successful.
     CriteriaMethod: [metrics_score, metrics_score_maph] # Method name of criteria (num_tp/metrics_score/metrics_score_maph)
-    CriteriaLevel: 10.0 # Level of criteria (perfect/hard/normal/easy, or custom value 0.0-100.0)
+    CriteriaLevel: [10.0, 10.0] # Level of criteria (perfect/hard/normal/easy, or custom value 0.0-100.0)
   PerceptionEvaluationConfig:
     evaluation_config_dict:
       evaluation_task: detection # detection or tracking. Evaluate the objects specified here

--- a/sample/perception/scenario.criteria.custom.yaml
+++ b/sample/perception/scenario.criteria.custom.yaml
@@ -13,7 +13,7 @@ Evaluation:
         LocalMapPath: $HOME/autoware_map/sample-map-planning # Specify LocalMapPath for each data set.
   Conditions:
     PassRate: 95.0 # How much (%) of the evaluation attempts are considered successful.
-    CriteriaMethod: [metrics_score, metrics_score_maph] # Method name of criteria (num_tp/metrics_score)
+    CriteriaMethod: [metrics_score, metrics_score_maph] # Method name of criteria (num_tp/metrics_score/metrics_score_maph)
     CriteriaLevel: 10.0 # Level of criteria (perfect/hard/normal/easy, or custom value 0.0-100.0)
   PerceptionEvaluationConfig:
     evaluation_config_dict:

--- a/sample/perception/scenario.fp.ja.yaml
+++ b/sample/perception/scenario.fp.ja.yaml
@@ -13,7 +13,7 @@ Evaluation:
         LocalMapPath: $HOME/autoware_map/sample-map-planning # データセット毎にLocalMapPathを指定する
   Conditions:
     PassRate: 99.0 # 評価試行回数の内、どの程度(%)評価成功だったら成功とするか
-    CriteriaMethod: num_tp # クライテリアメソッド名(num_tp/metrics_score)
+    CriteriaMethod: num_tp # クライテリアメソッド名(num_tp/metrics_score/metrics_score_maph)
     CriteriaLevel: easy # クライテリアレベル(perfect/hard/normal/easy、もしくはカスタム値0.0〜100.0の数値)
   PerceptionEvaluationConfig:
     evaluation_config_dict:

--- a/sample/perception/scenario.fp.yaml
+++ b/sample/perception/scenario.fp.yaml
@@ -13,7 +13,7 @@ Evaluation:
         LocalMapPath: $HOME/autoware_map/sample-map-planning # Specify LocalMapPath for each data set.
   Conditions:
     PassRate: 99.0 # How much (%) of the evaluation attempts are considered successful.
-    CriteriaMethod: num_tp # Method name of criteria (num_tp/metrics_score)
+    CriteriaMethod: num_tp # Method name of criteria (num_tp/metrics_score/metrics_score_maph)
     CriteriaLevel: easy # Level of criteria (perfect/hard/normal/easy, or custom value 0.0-100.0)
   PerceptionEvaluationConfig:
     evaluation_config_dict:

--- a/sample/perception/scenario.ja.yaml
+++ b/sample/perception/scenario.ja.yaml
@@ -13,7 +13,7 @@ Evaluation:
         LocalMapPath: $HOME/autoware_map/sample-map-planning # データセット毎にLocalMapPathを指定する
   Conditions:
     PassRate: 99.0 # 評価試行回数の内、どの程度(%)評価成功だったら成功とするか
-    CriteriaMethod: num_tp # クライテリアメソッド名(num_tp/metrics_score)
+    CriteriaMethod: num_tp # クライテリアメソッド名(num_tp/metrics_score/metrics_score_maph)
     CriteriaLevel: easy # クライテリアレベル(perfect/hard/normal/easy、もしくはカスタム値0.0〜100.0の数値)
   PerceptionEvaluationConfig:
     evaluation_config_dict:

--- a/sample/perception/scenario.yaml
+++ b/sample/perception/scenario.yaml
@@ -13,7 +13,7 @@ Evaluation:
         LocalMapPath: $HOME/autoware_map/sample-map-planning # Specify LocalMapPath for each data set.
   Conditions:
     PassRate: 95.0 # How much (%) of the evaluation attempts are considered successful.
-    CriteriaMethod: num_tp # Method name of criteria (num_tp/metrics_score)
+    CriteriaMethod: num_tp # Method name of criteria (num_tp/metrics_score/metrics_score_maph)
     CriteriaLevel: easy # Level of criteria (perfect/hard/normal/easy, or custom value 0.0-100.0)
   PerceptionEvaluationConfig:
     evaluation_config_dict:


### PR DESCRIPTION
## Types of PR

- [x] New Features
- [ ] Upgrade of existing features
- [ ] Bugfix

## Description

### Basic idea

In order to support yaw-based error evaluation for `Perception` scenarios, **I would like to add `metrics_score_maph` criteria in driving_log_replayer**, which is based on Maph. Note that `metrics_score` ideally should be renamed to `metrics_score_map`, but I do not make this change to maintain backward compatibility. 

In addition, in order to enable users to evaluate a scenario using two or more metrics (e.g. `metrics_score` and `metrics_score_maph`), I propose to change the scenario format so that `CriteriaMethod` can also take List[CriteriaMethod].

### Tests

Ran with following scenario yaml files and confirmed that `dlr simulation run -p perception ...` runs successfully.
```yaml
  Conditions:
    PassRate: 95.0
    CriteriaMethod: metrics_score
    CriteriaLevel: 10.0
```
```yaml
  Conditions:
    PassRate: 95.0
    CriteriaMethod: [metrics_score, metrics_score_maph]
    CriteriaLevel: 10.0
```
```yaml
  Conditions:
    PassRate: 95.0
    CriteriaMethod: [metrics_score]
    CriteriaLevel: 10.0
```

Also, confirmed that the following file fails.
```yaml
  Conditions:
    PassRate: 95.0
    CriteriaMethod: [metrics_score, hoge]
    CriteriaLevel: 10.0
```

### Limitations
- The `Maph` metric may be meaningless for some classes, e.g. pedestrian, where yaw estimation is expected to perform worse than other classes. Also, current implementation uses unified threshold for all the classes, and thus **it is recommended to avoid enabling `Maph` in scenario where several classes are set as target labels**.
- Although `CriteriaMethod` can take both `str` or `List[str]` not only for Perception but also for Perception2D and TrafficLight scenarios, I do no enable this feature for those, since such request does not exists as far as I know. 
- This is just a minimal implementation for very first yaw estimation monitoring, and this may fail to detect some known issues, e.g. yaw estimation oscillation. In the near future we seek to extend the monitoring criterion, but for now we would like to start with a minimal set of metrics to see what to add next

## How to review this PR

Please execute the perception scenario with the scenario.criteria.custom.yaml, and verify that it runs without failure.

## Others

None