### PR TITLE
fix: add handling of cases where non_detection is disabled

### DIFF
--- a/driving_log_replayer/scripts/obstacle_segmentation_evaluator_node.py
+++ b/driving_log_replayer/scripts/obstacle_segmentation_evaluator_node.py
@@ -306,10 +306,13 @@ class ObstacleSegmentationEvaluator(DLREvaluator):
         map_to_baselink: TransformStamped,
         base_link_to_map: TransformStamped,
     ) -> tuple[MarkerArray, list]:
-        s_proposed_area = self._scenario.Evaluation.Conditions.NonDetection.ProposedArea
-        # get proposed_area in map
         non_detection_area_markers = MarkerArray()
         non_detection_areas = []
+        cond_non_detection = self._scenario.Evaluation.Conditions.NonDetection
+        if cond_non_detection is None:
+            return non_detection_area_markers, non_detection_areas
+        s_proposed_area = cond_non_detection.ProposedArea
+        # get proposed_area in map
         proposed_area_in_map, average_z = transform_proposed_area(
             s_proposed_area,
             header,


### PR DESCRIPTION
## Types of PR

- [x] Bugfix

## Description

- Fix access to null object
- Fixed a runtime error when Conditions.NonDetection is null.

```shell
[obstacle_segmentation_evaluator_node.py-66]   File "/home/autoware/pilot-auto.x1/install/driving_log_replayer/lib/driving_log_replayer/obstacle_segmentation_evaluator_node.py", line 358, in <module>
[obstacle_segmentation_evaluator_node.py-66]     main()
[obstacle_segmentation_evaluator_node.py-66]   File "/home/autoware/pilot-auto.x1/install/driving_log_replayer/local/lib/python3.10/dist-packages/driving_log_replayer/evaluator.py", line 449, in wrapper
[obstacle_segmentation_evaluator_node.py-66]     evaluator = func()
[obstacle_segmentation_evaluator_node.py-66]   File "/home/autoware/pilot-auto.x1/install/driving_log_replayer/lib/driving_log_replayer/obstacle_segmentation_evaluator_node.py", line 354, in main
[obstacle_segmentation_evaluator_node.py-66]     return ObstacleSegmentationEvaluator("obstacle_segmentation_evaluator")
[obstacle_segmentation_evaluator_node.py-66]   File "/home/autoware/pilot-auto.x1/install/driving_log_replayer/lib/driving_log_replayer/obstacle_segmentation_evaluator_node.py", line 87, in __init__
[obstacle_segmentation_evaluator_node.py-66]     self._scenario.Evaluation.Conditions.NonDetection.ProposedArea.search_range()
[obstacle_segmentation_evaluator_node.py-66] AttributeError: 'NoneType' object has no attribute 'ProposedArea'
```

## How to review this PR

```shell
webauto ci scenario run --project-id odd2_reference --scenario-id c4ec5eda-dec9-47ae-bda3-22ba774a400c --scenario-version-id 12 --scenario-parameters 't4_dataset_id=22c55e38-c61c-4cf4-a20d-bb397c09844a,t4_dataset_version_id=0'
```

## Others
