### PR TITLE
feat: add support of label metrics

### DIFF
--- a/driving_log_replayer/driving_log_replayer/criteria/perception.py
+++ b/driving_log_replayer/driving_log_replayer/criteria/perception.py
@@ -407,6 +407,8 @@ class PerceptionCriteria:
         for method, level in zip(methods, levels, strict=True):
             if method == CriteriaMethod.NUM_TP:
                 self.methods.append(NumTP(level))
+            elif method == CriteriaMethod.LABEL:
+                self.methods.append(Label(level))
             elif method == CriteriaMethod.METRICS_SCORE:
                 self.methods.append(MetricsScore(level))
             elif method == CriteriaMethod.METRICS_SCORE_MAPH:

--- a/driving_log_replayer/driving_log_replayer/perception.py
+++ b/driving_log_replayer/driving_log_replayer/perception.py
@@ -57,9 +57,9 @@ class Filter(BaseModel):
 
 class Criteria(BaseModel):
     PassRate: number
-    CriteriaMethod: Literal["num_tp", "metrics_score", "metrics_score_maph"] | list[str] | None = (
-        None
-    )
+    CriteriaMethod: (
+        Literal["num_tp", "label", "metrics_score", "metrics_score_maph"] | list[str] | None
+    ) = None
     CriteriaLevel: (
         Literal["perfect", "hard", "normal", "easy"] | list[str] | number | list[number] | None
     ) = None


### PR DESCRIPTION
## Types of PR

- [x] New Features

## Description

Add support of `label` metrics.
This metrics calculating score with the following policy:

- Check whether label is correct if the object result has the pair of GT.
  - If the result is FN, it means there is no corresponding GT, skip scoring.

scenario example:

```
Conditions:
    Criterion:
      - PassRate: 95.0 # How much (%) of the evaluation attempts are considered successful.
        CriteriaMethod: label # Method name of criteria (num_tp/label/metrics_score)
        CriteriaLevel: hard # Level of criteria (perfect/hard/normal/easy, or custom value 0.0-100.0)
        Filter:
          Distance: 0.0-50.0 # [m] null [Do not filter by distance] or lower_limit-(upper_limit) [Upper limit can be omitted. If omitted value is 1.7976931348623157e+308]
      ...
```

## How to review this PR

## Others
