### PR TITLE
fix: localization default success value

### DIFF
--- a/driving_log_replayer/driving_log_replayer/localization.py
+++ b/driving_log_replayer/driving_log_replayer/localization.py
@@ -77,7 +77,6 @@ class LocalizationScenario(Scenario):
 @dataclass
 class Convergence(EvaluationItem):
     name: str = "Convergence"
-    success: bool = True
 
     def set_frame(
         self,
@@ -126,7 +125,6 @@ class Convergence(EvaluationItem):
 @dataclass
 class Reliability(EvaluationItem):
     name: str = "Reliability"
-    success: bool = True
     ng_seq: int = 0
     received_data: list[float] = field(default_factory=list)
 
@@ -167,7 +165,6 @@ class Reliability(EvaluationItem):
 @dataclass
 class Availability(EvaluationItem):
     name: str = "NDT Availability"
-    success: bool = True
     TARGET_DIAG_NAME: ClassVar[str] = (
         "/autoware/localization/node_alive_monitoring/topic_status/topic_state_monitor_ndt_scan_matcher_exe_time: localization_topic_status"
     )

--- a/driving_log_replayer/driving_log_replayer/localization.py
+++ b/driving_log_replayer/driving_log_replayer/localization.py
@@ -140,7 +140,7 @@ class Reliability(EvaluationItem):
         self.received_data.append(msg.data)
 
         # If the likelihood is lower than AllowableLikelihood for NGCount consecutive times, it is assumed to be a failure.
-        if self.success:
+        if self.ng_seq < self.condition.NGCount:
             # Update nq_seq only while reliability.result is true
             if msg.data >= self.condition.AllowableLikelihood:
                 self.ng_seq = 0
@@ -197,7 +197,10 @@ class Availability(EvaluationItem):
             return {
                 "Ego": {},
                 "Availability": {
-                    "Result": {"Total": self.success_str(), "Frame": self.success_str()},
+                    "Result": {
+                        "Total": self.success_str(),
+                        "Frame": self.success_str(),
+                    },
                     "Info": {},
                 },
             }
@@ -205,7 +208,9 @@ class Availability(EvaluationItem):
             "Ego": {},
             "Availability": {
                 "Result": {"Total": self.success_str(), "Frame": "Warn"},
-                "Info": {"Reason": "diagnostics does not contain localization_topic_status"},
+                "Info": {
+                    "Reason": "diagnostics does not contain localization_topic_status",
+                },
             },
         }
 

--- a/driving_log_replayer/test/unittest/test_localization.py
+++ b/driving_log_replayer/test/unittest/test_localization.py
@@ -98,12 +98,12 @@ def test_availability_has_no_target_diag() -> None:
     status = DiagnosticStatus(name="not_localization_diag_name")
     evaluation_item = Availability()
     frame_dict = evaluation_item.set_frame(DiagnosticArray(status=[status]))
-    assert evaluation_item.success is True
+    assert evaluation_item.success is False
     assert evaluation_item.summary == "NotTested"
     assert frame_dict == {
         "Ego": {},
         "Availability": {
-            "Result": {"Total": "Success", "Frame": "Warn"},
+            "Result": {"Total": "Fail", "Frame": "Warn"},
             "Info": {"Reason": "diagnostics does not contain localization_topic_status"},
         },
     }


### PR DESCRIPTION
## Types of PR

- [x] Bugfix

## Description

- fix default value of EvaluationItem.success

## How to review this PR

TIER IV internal

Applying this PR changes the result from Success to Fail

```shell
wasim run --project-id x2_dev --scenario-id 2d6d0b4b-ed50-4657-98f4-6e48b14eddaf --scenario-version 10
```

## Others

same as 06fab5312529ec06573ff7aa41eea2b88119369b
