### PR TITLE
feat(perception): add support of velocity criteria

### DIFF
--- a/driving_log_replayer/driving_log_replayer/criteria/perception.py
+++ b/driving_log_replayer/driving_log_replayer/criteria/perception.py
@@ -18,11 +18,11 @@ from __future__ import annotations
 from abc import ABC
 from abc import abstractmethod
 from enum import Enum
-import math
 from numbers import Number
 from typing import TYPE_CHECKING
 
 import numpy as np
+
 from perception_eval.common.evaluation_task import EvaluationTask
 from perception_eval.evaluation.matching import MatchingMode
 from perception_eval.tool.utils import filter_frame_by_distance

--- a/driving_log_replayer/driving_log_replayer/criteria/perception.py
+++ b/driving_log_replayer/driving_log_replayer/criteria/perception.py
@@ -74,7 +74,7 @@ class CriteriaLevel(Enum):
 
     CUSTOM = None
 
-    def is_valid(self, score: Number, is_error: bool) -> bool:
+    def is_valid(self, score: Number, *, is_error: bool) -> bool:
         """
         Return whether the score satisfied the level.
 
@@ -207,7 +207,9 @@ class CriteriaMethodImpl(ABC):
             return None
         score: float = self.calculate_score(frame)
         return (
-            SuccessFail.SUCCESS if self.level.is_valid(score, self.is_error) else SuccessFail.FAIL
+            SuccessFail.SUCCESS
+            if self.level.is_valid(score, is_error=self.is_error)
+            else SuccessFail.FAIL
         )
 
     @staticmethod

--- a/driving_log_replayer/driving_log_replayer/criteria/perception.py
+++ b/driving_log_replayer/driving_log_replayer/criteria/perception.py
@@ -146,9 +146,9 @@ class CriteriaMethod(Enum):
 
     NUM_TP = "num_tp"
     LABEL = "label"
-    VELOCITY_X = "velocity_x"
-    VELOCITY_Y = "velocity_y"
-    VELOCITY_NORM = "velocity_norm"
+    VELOCITY_X_ERROR = "velocity_x_error"
+    VELOCITY_Y_ERROR = "velocity_y_error"
+    SPEED_ERROR = "speed_error"
     METRICS_SCORE = "metrics_score"
     METRICS_SCORE_MAPH = "metrics_score_maph"
 
@@ -291,8 +291,8 @@ class Label(CriteriaMethodImpl):
         return True
 
 
-class VelocityX(CriteriaMethodImpl):
-    name = CriteriaMethod.VELOCITY_X
+class VelocityXError(CriteriaMethodImpl):
+    name = CriteriaMethod.VELOCITY_X_ERROR
 
     def __init__(self, level: CriteriaLevel) -> None:
         super().__init__(level)
@@ -313,8 +313,8 @@ class VelocityX(CriteriaMethodImpl):
         return False
 
 
-class VelocityY(CriteriaMethodImpl):
-    name = CriteriaMethod.VELOCITY_Y
+class VelocityYError(CriteriaMethodImpl):
+    name = CriteriaMethod.VELOCITY_Y_ERROR
 
     def __init__(self, level: CriteriaLevel) -> None:
         super().__init__(level)
@@ -335,8 +335,8 @@ class VelocityY(CriteriaMethodImpl):
         return False
 
 
-class VelocityNorm(CriteriaMethodImpl):
-    name = CriteriaMethod.VELOCITY_NORM
+class SpeedError(CriteriaMethodImpl):
+    name = CriteriaMethod.SPEED_ERROR
 
     def __init__(self, level: CriteriaLevel) -> None:
         super().__init__(level)
@@ -510,12 +510,12 @@ class PerceptionCriteria:
                 self.methods.append(NumTP(level))
             elif method == CriteriaMethod.LABEL:
                 self.methods.append(Label(level))
-            elif method == CriteriaMethod.VELOCITY_X:
-                self.methods.append(VelocityX(level))
-            elif method == CriteriaMethod.VELOCITY_Y:
-                self.methods.append(VelocityY(level))
-            elif method == CriteriaMethod.VELOCITY_NORM:
-                self.methods.append(VelocityNorm(level))
+            elif method == CriteriaMethod.VELOCITY_X_ERROR:
+                self.methods.append(VelocityXError(level))
+            elif method == CriteriaMethod.VELOCITY_Y_ERROR:
+                self.methods.append(VelocityYError(level))
+            elif method == CriteriaMethod.SPEED_ERROR:
+                self.methods.append(SpeedError(level))
             elif method == CriteriaMethod.METRICS_SCORE:
                 self.methods.append(MetricsScore(level))
             elif method == CriteriaMethod.METRICS_SCORE_MAPH:

--- a/driving_log_replayer/driving_log_replayer/criteria/perception.py
+++ b/driving_log_replayer/driving_log_replayer/criteria/perception.py
@@ -349,8 +349,8 @@ class SpeedError(CriteriaMethodImpl):
         errors = []
         for result in frame.object_results:
             if result.ground_truth_object is not None:
-                est_norm = math.hypot(result.estimated_object.state.velocity[:2])
-                gt_norm = math.hypot(result.ground_truth_object.state.velocity[:2])
+                est_norm = np.linalg.norm(result.estimated_object.state.velocity[:2])
+                gt_norm = np.linalg.norm(result.ground_truth_object.state.velocity[:2])
                 err = abs(gt_norm - est_norm)
                 errors.append(err)
         return 0.0 if len(errors) == 0 else np.mean(errors)

--- a/driving_log_replayer/driving_log_replayer/criteria/perception.py
+++ b/driving_log_replayer/driving_log_replayer/criteria/perception.py
@@ -138,6 +138,9 @@ class CriteriaMethod(Enum):
 
     - NUM_TP: Number of TP (or TN).
     - LABEL: Whether label is correct or not.
+    - VELOCITY_X_ERROR: Error of x direction velocity [m/s].
+    - VELOCITY_Y_ERROR: Error of y direction velocity [m/s].
+    - SPEED_ERROR: Error of speed [m/s].
     - METRICS_SCORE: Accuracy score for classification, otherwise mAP score is used.
     - METRICS_SCORE_MAPH: mAPH score.
     """

--- a/driving_log_replayer/driving_log_replayer/perception.py
+++ b/driving_log_replayer/driving_log_replayer/perception.py
@@ -59,7 +59,17 @@ class Filter(BaseModel):
 class Criteria(BaseModel):
     PassRate: number
     CriteriaMethod: (
-        Literal["num_tp", "label", "metrics_score", "metrics_score_maph", "velocity_x_error", "velocity_y_error", "speed_error"] | list[str] | None
+        Literal[
+            "num_tp",
+            "label",
+            "metrics_score",
+            "metrics_score_maph",
+            "velocity_x_error",
+            "velocity_y_error",
+            "speed_error",
+        ]
+        | list[str]
+        | None
     ) = None
     CriteriaLevel: (
         Literal["perfect", "hard", "normal", "easy"] | list[str] | number | list[number] | None

--- a/driving_log_replayer/driving_log_replayer/perception.py
+++ b/driving_log_replayer/driving_log_replayer/perception.py
@@ -59,7 +59,7 @@ class Filter(BaseModel):
 class Criteria(BaseModel):
     PassRate: number
     CriteriaMethod: (
-        Literal["num_tp", "label", "metrics_score", "metrics_score_maph"] | list[str] | None
+        Literal["num_tp", "label", "metrics_score", "metrics_score_maph", "velocity_x_error", "velocity_y_error", "speed_error"] | list[str] | None
     ) = None
     CriteriaLevel: (
         Literal["perfect", "hard", "normal", "easy"] | list[str] | number | list[number] | None

--- a/sample/perception/scenario.criteria.custom.yaml
+++ b/sample/perception/scenario.criteria.custom.yaml
@@ -14,7 +14,7 @@ Evaluation:
   Conditions:
     Criterion:
       - PassRate: 95.0 # How much (%) of the evaluation attempts are considered successful.
-        CriteriaMethod: [metrics_score, metrics_score_maph] # Method name of criteria (num_tp/metrics_score/metrics_score_maph)
+        CriteriaMethod: [metrics_score, metrics_score_maph] # Method name of criteria (num_tp/metrics_score/metrics_score_maph/label/velocity_x_error/velocity_y_error/speed_error)
         CriteriaLevel: [10.0, 10.0] # Level of criteria (perfect/hard/normal/easy, or custom value 0.0-100.0)
         Filter:
           Distance: null # [m] null [Do not filter by distance] or lower_limit-(upper_limit) [Upper limit can be omitted. If omitted value is 1.7976931348623157e+308]

--- a/sample/perception/scenario.ja.yaml
+++ b/sample/perception/scenario.ja.yaml
@@ -14,13 +14,13 @@ Evaluation:
   Conditions:
     Criterion:
       - PassRate: 95.0 # 評価試行回数の内、どの程度(%)評価成功だったら成功とするか
-        CriteriaMethod: num_tp # クライテリアメソッド名(num_tp/metrics_score/metrics_score_maph)
-        CriteriaLevel: hard # クライテリアレベル(perfect/hard/normal/easy、もしくはカスタム値0.0〜100.0の数値)
+        CriteriaMethod: num_tp # クライテリアメソッド名(num_tp/metrics_score/metrics_score_maph/label/velocity_x_error/velocity_y_error/speed_error)
+        CriteriaLevel: hard # クライテリアレベル(perfect/hard/normal/easy、もしくはカスタム値0.0〜100.0の数値でエラーの場合は許容誤差を指定。)
         Filter:
           Distance: 0.0-50.0 # [m] null [距離でフィルタしない] or 下限-(上限) [上限は省略可。省略した場合1.7976931348623157e+308]
       - PassRate: 95.0 # 評価試行回数の内、どの程度(%)評価成功だったら成功とするか
-        CriteriaMethod: num_tp # クライテリアメソッド名(num_tp/metrics_score/metrics_score_maph)
-        CriteriaLevel: easy # クライテリアレベル(perfect/hard/normal/easy、もしくはカスタム値0.0〜100.0の数値)
+        CriteriaMethod: num_tp # クライテリアメソッド名(num_tp/metrics_score/metrics_score_maph/label/velocity_x_error/velocity_y_error/speed_error)
+        CriteriaLevel: easy # クライテリアレベル(perfect/hard/normal/easy、もしくはカスタム値0.0〜100.0の数値でエラーの場合は許容誤差を指定。)
         Filter:
           Distance: 50.0- # [m] null [距離でフィルタしない] or 下限-(上限) [上限は省略可。省略した場合1.7976931348623157e+308]
   PerceptionEvaluationConfig:

--- a/sample/perception/scenario.yaml
+++ b/sample/perception/scenario.yaml
@@ -14,13 +14,13 @@ Evaluation:
   Conditions:
     Criterion:
       - PassRate: 95.0 # How much (%) of the evaluation attempts are considered successful.
-        CriteriaMethod: num_tp # Method name of criteria (num_tp/metrics_score)
-        CriteriaLevel: hard # Level of criteria (perfect/hard/normal/easy, or custom value 0.0-100.0)
+        CriteriaMethod: num_tp # Method name of criteria (num_tp/metrics_score/metrics_score_mph/label/velocity_x_error/velocity_y_error/speed_error)
+        CriteriaLevel: hard # Level of criteria (perfect/hard/normal/easy, or custom value 0.0-100.0. For error criteria, set custom value.)
         Filter:
           Distance: 0.0-50.0 # [m] null [Do not filter by distance] or lower_limit-(upper_limit) [Upper limit can be omitted. If omitted value is 1.7976931348623157e+308]
       - PassRate: 95.0 # How much (%) of the evaluation attempts are considered successful.
-        CriteriaMethod: num_tp # Method name of criteria (num_tp/metrics_score)
-        CriteriaLevel: easy # Level of criteria (perfect/hard/normal/easy, or custom value 0.0-100.0)
+        CriteriaMethod: num_tp # Method name of criteria (num_tp/metrics_score/metrics_score_mph/label/velocity_x_error/velocity_y_error/speed_error)
+        CriteriaLevel: easy # Level of criteria (perfect/hard/normal/easy, or custom value 0.0-100.0. For error criteria, set custom value.)
         Filter:
           Distance: 50.0- # [m] null [Do not filter by distance] or lower_limit-(upper_limit) [Upper limit can be omitted. If omitted value is 1.7976931348623157e+308]
   PerceptionEvaluationConfig:


### PR DESCRIPTION
## Types of PR

- [x] New Features

## Description

Add support of velocity criteria.

- `VELOCITY_X_ERROR`: Calculate an error of x direction velocity.
- `VELOCITY_Y_ERROR`: Calculate an error of y direction velocity.
- `SPEED_ERROR`: Calculate an error of velocity norm.

Each criteria calculates the absolute error in scalar.

![VelocityCriteria](https://github.com/tier4/driving_log_replayer/assets/60615504/85b4ee72-de4a-4988-a528-bbd0f0aa1aaa)

## How to review this PR

## Others
