### PR TITLE
feat: Change processing to match the diagnostics data structure

### DIFF
--- a/driving_log_replayer/driving_log_replayer/performance_diag.py
+++ b/driving_log_replayer/driving_log_replayer/performance_diag.py
@@ -14,12 +14,9 @@
 
 
 from dataclasses import dataclass
-from functools import singledispatchmethod
-import re
 from typing import ClassVar
 from typing import Literal
 
-from diagnostic_msgs.msg import DiagnosticArray
 from diagnostic_msgs.msg import DiagnosticStatus
 from diagnostic_msgs.msg import KeyValue
 from example_interfaces.msg import Byte
@@ -90,9 +87,6 @@ class PerformanceDiagScenario(Scenario):
 @dataclass
 class Visibility(EvaluationItem):
     name: str = "Visibility"
-    REGEX_VISIBILITY_DIAG_NAME: ClassVar[str] = (
-        "dual_return_filter: /sensing/lidar/.*: visibility_validation"
-    )
     VALID_VALUE_THRESHOLD: ClassVar[float] = 0.0
 
     def __post_init__(self) -> None:
@@ -100,7 +94,7 @@ class Visibility(EvaluationItem):
         self.scenario_type: str | None = self.condition.ScenarioType
         self.valid: bool = self.scenario_type is not None
 
-    def set_frame(self, msg: DiagnosticArray) -> tuple[dict, Float64 | None, Byte | None]:
+    def set_frame(self, diag_status: DiagnosticStatus) -> tuple[dict, Float64 | None, Byte | None]:
         if not self.valid:
             self.success = True
             self.summary = "Invalid"
@@ -110,52 +104,37 @@ class Visibility(EvaluationItem):
                 None,
             )
         frame_success = "Fail"
-        diag_status: DiagnosticStatus
-        for diag_status in msg.status:
-            if not re.fullmatch(Visibility.REGEX_VISIBILITY_DIAG_NAME, diag_status.name):
-                continue
-            self.total += 1
-            visibility_value = get_diag_value(diag_status, "value")
-            diag_level = diag_status.level
-            if self.scenario_type == "TP":
-                if diag_level == DiagnosticStatus.ERROR:
-                    frame_success = "Success"
-                    self.passed += 1
-                self.success = self.passed >= self.condition.PassFrameCount
-            elif self.scenario_type == "FP":
-                if diag_level != DiagnosticStatus.ERROR:
-                    frame_success = "Success"
-                    self.passed += 1
-                self.success = self.passed == self.total
-            self.summary = f"{self.name} ({self.success_str()}): {self.passed} / {self.total}"
-            float_value = convert_str_to_float(visibility_value)
-            valid_value = float_value >= Visibility.VALID_VALUE_THRESHOLD
-            return (
-                {
-                    "Result": {"Total": self.success_str(), "Frame": frame_success},
-                    "Info": {
-                        "Level": int.from_bytes(diag_level, byteorder="little"),
-                        "Value": float_value,
-                    },
-                },
-                Float64(data=float_value) if valid_value else None,
-                Byte(data=diag_level) if valid_value else None,
-            )
+        self.total += 1
+        visibility_value = get_diag_value(diag_status, "value")
+        diag_level = diag_status.level
+        if self.scenario_type == "TP":
+            if diag_level == DiagnosticStatus.ERROR:
+                frame_success = "Success"
+                self.passed += 1
+            self.success = self.passed >= self.condition.PassFrameCount
+        elif self.scenario_type == "FP":
+            if diag_level != DiagnosticStatus.ERROR:
+                frame_success = "Success"
+                self.passed += 1
+            self.success = self.passed == self.total
+        self.summary = f"{self.name} ({self.success_str()}): {self.passed} / {self.total}"
+        float_value = convert_str_to_float(visibility_value)
+        valid_value = float_value >= Visibility.VALID_VALUE_THRESHOLD
         return (
             {
-                "Result": {"Total": self.success_str(), "Frame": "Warn"},
-                "Info": {"Reason": "diagnostics does not contain visibility"},
+                "Result": {"Total": self.success_str(), "Frame": frame_success},
+                "Info": {
+                    "Level": int.from_bytes(diag_level, byteorder="little"),
+                    "Value": float_value,
+                },
             },
-            None,
-            None,
+            Float64(data=float_value) if valid_value else None,
+            Byte(data=diag_level) if valid_value else None,
         )
 
 
 @dataclass
 class Blockage(EvaluationItem):
-    # sample: blockage_return_diag: /sensing/lidar/left_lower: blockage_validation
-    BLOCKAGE_DIAG_BASE_NAME: ClassVar[str] = "blockage_return_diag: /sensing/lidar/"
-    BLOCKAGE_DIAG_POSTFIX: ClassVar[str] = ": blockage_validation"
     VALID_VALUE_THRESHOLD: ClassVar[float] = 0.0
 
     def __post_init__(self) -> None:
@@ -164,57 +143,52 @@ class Blockage(EvaluationItem):
         self.blockage_type: str = self.condition.BlockageType
         self.pass_frame_count: int = self.condition.PassFrameCount
         self.valid: bool = self.scenario_type is not None
-        self.blockage_name = (
-            Blockage.BLOCKAGE_DIAG_BASE_NAME + self.name + Blockage.BLOCKAGE_DIAG_POSTFIX
-        )
 
     def set_frame(
         self,
-        msg: DiagnosticStatus,
+        diag_status: DiagnosticStatus,
     ) -> tuple[dict, Float64 | None, Float64 | None, Byte | None]:
         if not self.valid:
             self.success = True
             self.summary = "Invalid"
             return (
-                {"Result": {"Total": self.success_str(), "Frame": "Invalid"}, "Info": {}},
-                None,
-                None,
-                None,
-            )
-        diag_status: DiagnosticStatus
-        frame_success = "Fail"
-        for diag_status in msg.status:
-            if diag_status.name != self.blockage_name:
-                continue
-            self.total += 1
-            ground_ratio = get_diag_value(diag_status, "ground_blockage_ratio")
-            sky_ratio = get_diag_value(diag_status, "sky_blockage_ratio")
-            diag_level = diag_status.level
-            if self.scenario_type == "TP":
-                if (
-                    diag_level == DiagnosticStatus.ERROR
-                    and self.blockage_type in diag_status.message
-                ):
-                    frame_success = "Success"
-                    self.passed += 1
-                self.success = self.passed >= self.pass_frame_count
-            elif self.scenario_type == "FP":
-                if not (
-                    diag_level == DiagnosticStatus.ERROR
-                    and self.blockage_type in diag_status.message
-                ):
-                    frame_success = "Success"
-                    self.passed += 1
-                self.success = self.passed == self.total
-            self.summary = f"{self.name} ({self.success_str()}): {self.passed} / {self.total}"
-            float_sky_ratio = convert_str_to_float(sky_ratio)
-            float_ground_ratio = convert_str_to_float(ground_ratio)
-            valid_ratio = (
-                float_sky_ratio >= Blockage.VALID_VALUE_THRESHOLD
-                and float_ground_ratio >= Blockage.VALID_VALUE_THRESHOLD
-            )
-            return (
                 {
+                    self.name: {
+                        "Result": {"Total": self.success_str(), "Frame": "Invalid"},
+                        "Info": {},
+                    },
+                },
+                None,
+                None,
+                None,
+            )
+        frame_success = "Fail"
+        self.total += 1
+        ground_ratio = get_diag_value(diag_status, "ground_blockage_ratio")
+        sky_ratio = get_diag_value(diag_status, "sky_blockage_ratio")
+        diag_level = diag_status.level
+        if self.scenario_type == "TP":
+            if diag_level == DiagnosticStatus.ERROR and self.blockage_type in diag_status.message:
+                frame_success = "Success"
+                self.passed += 1
+            self.success = self.passed >= self.pass_frame_count
+        elif self.scenario_type == "FP":
+            if not (
+                diag_level == DiagnosticStatus.ERROR and self.blockage_type in diag_status.message
+            ):
+                frame_success = "Success"
+                self.passed += 1
+            self.success = self.passed == self.total
+        self.summary = f"{self.name} ({self.success_str()}): {self.passed} / {self.total}"
+        float_sky_ratio = convert_str_to_float(sky_ratio)
+        float_ground_ratio = convert_str_to_float(ground_ratio)
+        valid_ratio = (
+            float_sky_ratio >= Blockage.VALID_VALUE_THRESHOLD
+            and float_ground_ratio >= Blockage.VALID_VALUE_THRESHOLD
+        )
+        return (
+            {
+                self.name: {
                     "Result": {
                         "Total": self.success_str(),
                         "Frame": frame_success,
@@ -231,19 +205,10 @@ class Blockage(EvaluationItem):
                         ),
                     },
                 },
-                Float64(data=float_sky_ratio) if valid_ratio else None,
-                Float64(data=float_ground_ratio) if valid_ratio else None,
-                Byte(data=diag_level) if valid_ratio else None,
-            )
-
-        return (
-            {
-                "Result": {"Total": self.success_str(), "Frame": "Warn"},
-                "Info": {"Reason": "diagnostics does not contain blockage"},
             },
-            None,
-            None,
-            None,
+            Float64(data=float_sky_ratio) if valid_ratio else None,
+            Float64(data=float_ground_ratio) if valid_ratio else None,
+            Byte(data=diag_level) if valid_ratio else None,
         )
 
 
@@ -267,64 +232,36 @@ class PerformanceDiagResult(ResultBase):
         self._success = tmp_success
         self._summary = prefix_str + tmp_summary
 
-    @singledispatchmethod
     def set_frame(self) -> None:
-        raise NotImplementedError
+        # abstract method
+        pass
 
-    @set_frame.register
     def set_visibility_frame(
         self,
         msg: DiagnosticStatus,
         map_to_baselink: dict,
     ) -> None:
-        self._frame = self.__visibility.set_frame(msg, map_to_baselink)
+        out_frame = {"Ego": {"TransformStamped": map_to_baselink}}
+        out_frame["Visibility"], msg_visibility_value, msg_visibility_level = (
+            self.__visibility.set_frame(msg)
+        )
+        self._frame = out_frame
         self.update()
+        return msg_visibility_value, msg_visibility_level
 
-    @set_frame.register
     def set_blockage_frame(
         self,
         msg: DiagnosticStatus,
         map_to_baselink: dict,
         lidar_name: str,
     ) -> None:
-        self._frame = self.__blockage[lidar_name].set_frame(msg, map_to_baselink)
-        self.update()
-
-    def set_frame(
-        self,
-        msg: DiagnosticArray,
-        map_to_baselink: dict,
-    ) -> tuple[
-        Float64 | None,
-        Byte | None,
-        dict[str, Float64],
-        dict[str, Float64],
-        dict[str, Byte],
-    ]:
-        msg_blockage_sky_ratios: dict[str, Float64] = {}
-        msg_blockage_ground_ratios: dict[str, Float64] = {}
-        msg_blockage_levels: dict[str, Byte] = {}
-
         out_frame = {"Ego": {"TransformStamped": map_to_baselink}}
         (
-            out_frame["Visibility"],
-            msg_visibility_value,
-            msg_visibility_level,
-        ) = self.__visibility.set_frame(msg)
-        out_frame["Blockage"] = {}
-        for k, v in self.__blockages.items():
-            (
-                out_frame["Blockage"][k],
-                msg_blockage_sky_ratios[k],
-                msg_blockage_ground_ratios[k],
-                msg_blockage_levels[k],
-            ) = v.set_frame(msg)
+            out_frame["Blockage"],
+            msg_blockage_sky_ratio,
+            msg_blockage_ground_ratio,
+            msg_blockage_level,
+        ) = self.__blockages[lidar_name].set_frame(msg)
         self._frame = out_frame
         self.update()
-        return (
-            msg_visibility_value,
-            msg_visibility_level,
-            msg_blockage_sky_ratios,
-            msg_blockage_ground_ratios,
-            msg_blockage_levels,
-        )
+        return msg_blockage_sky_ratio, msg_blockage_ground_ratio, msg_blockage_level

--- a/driving_log_replayer/driving_log_replayer/performance_diag.py
+++ b/driving_log_replayer/driving_log_replayer/performance_diag.py
@@ -14,6 +14,7 @@
 
 
 from dataclasses import dataclass
+from functools import singledispatchmethod
 import re
 from typing import ClassVar
 from typing import Literal
@@ -265,6 +266,29 @@ class PerformanceDiagResult(ResultBase):
         prefix_str = "Passed: " if tmp_success else "Failed: "
         self._success = tmp_success
         self._summary = prefix_str + tmp_summary
+
+    @singledispatchmethod
+    def set_frame(self) -> None:
+        raise NotImplementedError
+
+    @set_frame.register
+    def set_visibility_frame(
+        self,
+        msg: DiagnosticStatus,
+        map_to_baselink: dict,
+    ) -> None:
+        self._frame = self.__visibility.set_frame(msg, map_to_baselink)
+        self.update()
+
+    @set_frame.register
+    def set_blockage_frame(
+        self,
+        msg: DiagnosticStatus,
+        map_to_baselink: dict,
+        lidar_name: str,
+    ) -> None:
+        self._frame = self.__blockage[lidar_name].set_frame(msg, map_to_baselink)
+        self.update()
 
     def set_frame(
         self,

--- a/driving_log_replayer/scripts/performance_diag_evaluator_node.py
+++ b/driving_log_replayer/scripts/performance_diag_evaluator_node.py
@@ -30,6 +30,7 @@ class PerformanceDiagEvaluator(DLREvaluator):
     def __init__(self, name: str) -> None:
         super().__init__(name, PerformanceDiagScenario, PerformanceDiagResult)
         self._scenario: PerformanceDiagScenario
+        self._result: PerformanceDiagResult
 
         self.__pub_visibility_value = self.create_publisher(Float64, "visibility/value", 1)
         self.__pub_visibility_level = self.create_publisher(Byte, "visibility/level", 1)
@@ -54,7 +55,7 @@ class PerformanceDiagEvaluator(DLREvaluator):
                 self.__pub_blockage_levels[k] = self.create_publisher(
                     Byte,
                     f"blockage/{k}/level",
-                    1,
+                    100,
                 )
 
         self.__sub_diag = self.create_subscription(
@@ -65,8 +66,6 @@ class PerformanceDiagEvaluator(DLREvaluator):
         )
 
     def diag_cb(self, msg: DiagnosticArray) -> None:
-        if msg.header == self.__diag_header_prev:
-            return
         self.__diag_header_prev = msg.header
         map_to_baselink = self.lookup_transform(msg.header.stamp)
         (

--- a/driving_log_replayer/scripts/performance_diag_evaluator_node.py
+++ b/driving_log_replayer/scripts/performance_diag_evaluator_node.py
@@ -84,7 +84,7 @@ class PerformanceDiagEvaluator(DLREvaluator):
 
         map_to_baselink = self.lookup_transform(msg.header.stamp)
         if is_visibility:
-            msg_visibility_value, msg_visibility_level = self._result.set_frame(
+            msg_visibility_value, msg_visibility_level = self._result.set_visibility_frame(
                 diag_status,
                 DLREvaluator.transform_stamped_with_euler_angle(map_to_baselink),
             )

--- a/driving_log_replayer/test/unittest/test_performance_diag.py
+++ b/driving_log_replayer/test/unittest/test_performance_diag.py
@@ -43,34 +43,12 @@ def test_visibility_invalid() -> None:
     evaluation_item = Visibility(
         condition=VisibilityCondition(ScenarioType=None, PassFrameCount=100),
     )
-    frame_dict, msg_visibility_value, msg_visibility_level = evaluation_item.set_frame(
-        DiagnosticArray(status=[status]),
-    )
+    frame_dict, msg_visibility_value, msg_visibility_level = evaluation_item.set_frame(status)
     assert evaluation_item.success is True
     assert evaluation_item.summary == "Invalid"
     assert frame_dict == {
         "Result": {"Total": "Success", "Frame": "Invalid"},
         "Info": {},
-    }
-    assert msg_visibility_value is None
-    assert msg_visibility_level is None
-
-
-def test_visibility_has_no_target_diag() -> None:
-    status = DiagnosticStatus(name="not_visibility_diag_name")
-    evaluation_item = Visibility(
-        condition=VisibilityCondition(ScenarioType="TP", PassFrameCount=100),
-    )
-    frame_dict, msg_visibility_value, msg_visibility_level = evaluation_item.set_frame(
-        DiagnosticArray(status=[status]),
-    )
-    assert (
-        evaluation_item.success is False
-    )  # If there is no target status in the diag, SUCCESS is not updated. Default is false.
-    assert evaluation_item.summary == "NotTested"
-    assert frame_dict == {
-        "Result": {"Total": "Fail", "Frame": "Warn"},
-        "Info": {"Reason": "diagnostics does not contain visibility"},
     }
     assert msg_visibility_value is None
     assert msg_visibility_level is None
@@ -88,9 +66,7 @@ def test_visibility_tp_success() -> None:
         passed=99,
         success=False,
     )
-    frame_dict, msg_visibility_value, msg_visibility_level = evaluation_item.set_frame(
-        DiagnosticArray(status=[status]),
-    )
+    frame_dict, msg_visibility_value, msg_visibility_level = evaluation_item.set_frame(status)
     assert evaluation_item.success is True
     assert evaluation_item.summary == "Visibility (Success): 100 / 150"
     assert frame_dict == {
@@ -116,9 +92,7 @@ def test_visibility_tp_fail() -> None:
         passed=99,
         success=False,
     )
-    frame_dict, msg_visibility_value, msg_visibility_level = evaluation_item.set_frame(
-        DiagnosticArray(status=[status]),
-    )
+    frame_dict, msg_visibility_value, msg_visibility_level = evaluation_item.set_frame(status)
     assert evaluation_item.success is False
     assert evaluation_item.summary == "Visibility (Fail): 99 / 150"
     assert frame_dict == {
@@ -144,9 +118,7 @@ def test_visibility_fp_success() -> None:
         passed=49,
         success=True,
     )
-    frame_dict, msg_visibility_value, msg_visibility_level = evaluation_item.set_frame(
-        DiagnosticArray(status=[status]),
-    )
+    frame_dict, msg_visibility_value, msg_visibility_level = evaluation_item.set_frame(status)
     assert evaluation_item.success is True
     assert evaluation_item.summary == "Visibility (Success): 50 / 50"
     assert frame_dict == {
@@ -172,9 +144,7 @@ def test_visibility_fp_fail() -> None:
         passed=49,
         success=True,
     )
-    frame_dict, msg_visibility_value, msg_visibility_level = evaluation_item.set_frame(
-        DiagnosticArray(status=[status]),
-    )
+    frame_dict, msg_visibility_value, msg_visibility_level = evaluation_item.set_frame(status)
     assert evaluation_item.success is False
     assert evaluation_item.summary == "Visibility (Fail): 49 / 50"
     assert frame_dict == {
@@ -202,43 +172,14 @@ def test_blockage_invalid() -> None:
         msg_blockage_sky_ratio,
         msg_blockage_ground_ratio,
         msg_blockage_level,
-    ) = evaluation_item.set_frame(
-        DiagnosticArray(status=[status]),
-    )
+    ) = evaluation_item.set_frame(status)
     assert evaluation_item.success is True
     assert evaluation_item.summary == "Invalid"
     assert frame_dict == {
-        "Result": {"Total": "Success", "Frame": "Invalid"},
-        "Info": {},
-    }
-    assert msg_blockage_sky_ratio is None
-    assert msg_blockage_ground_ratio is None
-    assert msg_blockage_level is None
-
-
-def test_blockage_has_no_target_diag_not_target_lidar() -> None:
-    status = DiagnosticStatus(
-        name="blockage_return_diag: /sensing/lidar/rear_upper: blockage_validation",
-    )
-    evaluation_item = Blockage(
-        name="front_lower",
-        condition=BlockageCondition(ScenarioType="TP", BlockageType="both", PassFrameCount=100),
-    )
-    (
-        frame_dict,
-        msg_blockage_sky_ratio,
-        msg_blockage_ground_ratio,
-        msg_blockage_level,
-    ) = evaluation_item.set_frame(
-        DiagnosticArray(status=[status]),
-    )
-    assert (
-        evaluation_item.success is False
-    )  # If there is no target status in the diag, SUCCESS is not updated. Default is false.
-    assert evaluation_item.summary == "NotTested"
-    assert frame_dict == {
-        "Result": {"Total": "Fail", "Frame": "Warn"},
-        "Info": {"Reason": "diagnostics does not contain blockage"},
+        "front_lower": {
+            "Result": {"Total": "Success", "Frame": "Invalid"},
+            "Info": {},
+        },
     }
     assert msg_blockage_sky_ratio is None
     assert msg_blockage_ground_ratio is None
@@ -269,19 +210,19 @@ def test_blockage_tp_success() -> None:
         msg_blockage_sky_ratio,
         msg_blockage_ground_ratio,
         msg_blockage_level,
-    ) = evaluation_item.set_frame(
-        DiagnosticArray(status=[status]),
-    )
+    ) = evaluation_item.set_frame(status)
     assert evaluation_item.success is True
     assert evaluation_item.summary == "front_lower (Success): 100 / 150"
     assert frame_dict == {
-        "Result": {"Total": "Success", "Frame": "Success"},
-        "Info": {
-            "Level": 2,
-            "GroundBlockageRatio": 0.194444,
-            "GroundBlockageCount": 100,
-            "SkyBlockageRatio": 0.211706,
-            "SkyBlockageCount": 100,
+        "front_lower": {
+            "Result": {"Total": "Success", "Frame": "Success"},
+            "Info": {
+                "Level": 2,
+                "GroundBlockageRatio": 0.194444,
+                "GroundBlockageCount": 100,
+                "SkyBlockageRatio": 0.211706,
+                "SkyBlockageCount": 100,
+            },
         },
     }
     assert msg_blockage_sky_ratio == Float64(data=0.211706)
@@ -313,19 +254,19 @@ def test_blockage_tp_fail() -> None:
         msg_blockage_sky_ratio,
         msg_blockage_ground_ratio,
         msg_blockage_level,
-    ) = evaluation_item.set_frame(
-        DiagnosticArray(status=[status]),
-    )
+    ) = evaluation_item.set_frame(status)
     assert evaluation_item.success is False
     assert evaluation_item.summary == "front_lower (Fail): 99 / 150"
     assert frame_dict == {
-        "Result": {"Total": "Fail", "Frame": "Fail"},
-        "Info": {
-            "Level": 2,
-            "GroundBlockageRatio": -1.0,
-            "GroundBlockageCount": 1,
-            "SkyBlockageRatio": 0.824167,
-            "SkyBlockageCount": 100,
+        "front_lower": {
+            "Result": {"Total": "Fail", "Frame": "Fail"},
+            "Info": {
+                "Level": 2,
+                "GroundBlockageRatio": -1.0,
+                "GroundBlockageCount": 1,
+                "SkyBlockageRatio": 0.824167,
+                "SkyBlockageCount": 100,
+            },
         },
     }
     assert msg_blockage_sky_ratio is None
@@ -357,19 +298,19 @@ def test_blockage_fp_success() -> None:
         msg_blockage_sky_ratio,
         msg_blockage_ground_ratio,
         msg_blockage_level,
-    ) = evaluation_item.set_frame(
-        DiagnosticArray(status=[status]),
-    )
+    ) = evaluation_item.set_frame(status)
     assert evaluation_item.success is True
     assert evaluation_item.summary == "front_lower (Success): 50 / 50"
     assert frame_dict == {
-        "Result": {"Total": "Success", "Frame": "Success"},
-        "Info": {
-            "Level": 0,
-            "GroundBlockageRatio": 0.0,
-            "GroundBlockageCount": 0,
-            "SkyBlockageRatio": 0.380967,
-            "SkyBlockageCount": 50,
+        "front_lower": {
+            "Result": {"Total": "Success", "Frame": "Success"},
+            "Info": {
+                "Level": 0,
+                "GroundBlockageRatio": 0.0,
+                "GroundBlockageCount": 0,
+                "SkyBlockageRatio": 0.380967,
+                "SkyBlockageCount": 50,
+            },
         },
     }
     assert msg_blockage_sky_ratio == Float64(data=0.380967)
@@ -401,19 +342,19 @@ def test_blockage_fp_fail() -> None:
         msg_blockage_sky_ratio,
         msg_blockage_ground_ratio,
         msg_blockage_level,
-    ) = evaluation_item.set_frame(
-        DiagnosticArray(status=[status]),
-    )
+    ) = evaluation_item.set_frame(status)
     assert evaluation_item.success is False
     assert evaluation_item.summary == "front_lower (Fail): 49 / 50"
     assert frame_dict == {
-        "Result": {"Total": "Fail", "Frame": "Fail"},
-        "Info": {
-            "Level": 2,
-            "GroundBlockageRatio": 0.194444,
-            "GroundBlockageCount": 50,
-            "SkyBlockageRatio": 0.211706,
-            "SkyBlockageCount": 50,
+        "front_lower": {
+            "Result": {"Total": "Fail", "Frame": "Fail"},
+            "Info": {
+                "Level": 2,
+                "GroundBlockageRatio": 0.194444,
+                "GroundBlockageCount": 50,
+                "SkyBlockageRatio": 0.211706,
+                "SkyBlockageCount": 50,
+            },
         },
     }
     assert msg_blockage_sky_ratio == Float64(data=0.211706)


### PR DESCRIPTION
## Types of PR

- [x] Bugfix

## Description

- /diagnostics_agg has multiple DiagnosticsStatus in status, and the same HEADER STAMP TOPIC does not come
- /diagnostics has only one DiagnosticsStatus in the status, and multiple topics with the exact same header stamp are coming in.
- The logic was assuming /diagnostics_agg, so I changed the way it was handled.

## How to review this PR

TIER IV internal

```shell
webauto ci scenario run --project-id x2_dev --scenario-id a0b53b13-06a8-49b9-8a2a-bec2411c75f7

# result
Success": true, "Summary": "Passed: Visibility (Success): 615 / 619 Blockage: front_lower (Success): 615 / 615 front_upper (Success): 597 / 597 left_lower (Success): 605 / 605 left_upper (Success): 594 / 594 rear_lower (Success): 610 / 610 rear_upper (Success): 603 / 603 right_lower (Success): 630 / 630 right_upper (Success): 602 / 602"}
```

## Others

The depth of the subscriber was determined to be 100 by experimentation as shown in the attached txt.
[test_depth.txt](https://github.com/tier4/driving_log_replayer/files/15174980/test_depth.txt)


