### PR TITLE
feat: set use_perception_online_evaluator=true by default

### DIFF
--- a/docs/quick_start/annotationless_perception.en.md
+++ b/docs/quick_start/annotationless_perception.en.md
@@ -20,7 +20,7 @@
 1. Run the simulation
 
    ```shell
-   dlr simulation run -p annotationless_perception -l use_perception_online_evaluator:=true -l play_rate:=0.5
+   dlr simulation run -p annotationless_perception -l play_rate:=0.5
    ```
 
 2. Check the results

--- a/docs/quick_start/annotationless_perception.ja.md
+++ b/docs/quick_start/annotationless_perception.ja.md
@@ -20,7 +20,7 @@
 1. シミュレーションの実行
 
    ```shell
-   dlr simulation run -p annotationless_perception -l use_perception_online_evaluator:=true -l play_rate:=0.5
+   dlr simulation run -p annotationless_perception -l play_rate:=0.5
    ```
 
 2. 結果の確認

--- a/docs/use_case/annotationless_perception.en.md
+++ b/docs/use_case/annotationless_perception.en.md
@@ -5,9 +5,6 @@ Evaluate Autoware's recognition features (perception) without annotations using 
 Requires Autoware with the following PR features.
 <https://github.com/autowarefoundation/autoware.universe/pull/6556>
 
-Since it does not start by default, it is necessary to add use_perception_online_evaluator:=true to the launch argument.
-<https://github.com/autowarefoundation/autoware.universe/pull/6861>
-
 ## Evaluation method
 
 The annotationless_perception evaluation is executed by launching the `annotationless_perception.launch.py` file.
@@ -129,16 +126,16 @@ An image of its use is shown below.
 ##### driving-log-replayer-cli
 
 ```shell
-dlr simulation run -p annotationless_perception -l use_perception_online_evaluator:=true -l annotationless_threshold_file:=${previous_test_result.jsonl_path} -l 'annotationless_pass_range:={"KEY1":VALUE1"[,"KEY2":"VALUE2"...]}'
+dlr simulation run -p annotationless_perception -l annotationless_threshold_file:=${previous_test_result.jsonl_path} -l 'annotationless_pass_range:={"KEY1":VALUE1"[,"KEY2":"VALUE2"...]}'
 
 # example
-dlr simulation run -p annotationless_perception -l use_perception_online_evaluator:=true -l annotationless_threshold_file:=$HOME/out/annotationless/2024-0314-155106/sample/result.jsonl -l 'annotationless_pass_range:={"CAR":{"min":"0.0-1.1","max":"0.0-1.2","mean":"0.5-1.3"},"BUS":{"min":"0.0-1.1","max":"0.0-1.2","mean":"0.5-1.3"}}'
+dlr simulation run -p annotationless_perception -l annotationless_threshold_file:=$HOME/out/annotationless/2024-0314-155106/sample/result.jsonl -l 'annotationless_pass_range:={"CAR":{"min":"0.0-1.1","max":"0.0-1.2","mean":"0.5-1.3"},"BUS":{"min":"0.0-1.1","max":"0.0-1.2","mean":"0.5-1.3"}}'
 ```
 
 ##### WebAutoCLI
 
 ```shell
-webauto ci scenario run --project-id ${project-id} --scenario-id ${scenario-id} --scenario-version-id ${scenario-version-id} --simulator-parameter-overrides 'use_perception_online_evaluator=true,annotationless_threshold_file=${previous_test_result.jsonl_path},annotationless_pass_range:={"KEY1":VALUE1"[,"KEY2":"VALUE2"...]}'
+webauto ci scenario run --project-id ${project-id} --scenario-id ${scenario-id} --scenario-version-id ${scenario-version-id} --simulator-parameter-overrides 'annotationless_threshold_file=${previous_test_result.jsonl_path},annotationless_pass_range:={"KEY1":VALUE1"[,"KEY2":"VALUE2"...]}'
 ```
 
 ##### Autoware Evaluator
@@ -156,7 +153,6 @@ simulations:
       runtime:
         type: simulator/standard1/amd64/medium
       parameters:
-        use_perception_online_evaluator: "true"
         annotationless_threshold_file: ${previous_test_result.jsonl_path}
         annotationless_pass_range:
           KEY1: VALUE1
@@ -201,13 +197,13 @@ The following parameters are set to `false`:
 #### driving-log-replayer-cli
 
 ```shell
-dlr simulation run -p annotationless_perception -l use_perception_online_evaluator:=true -l sensing:=true
+dlr simulation run -p annotationless_perception -l sensing:=true
 ```
 
 #### WebAutoCLI
 
 ```shell
-webauto ci scenario run --project-id ${project-id} --scenario-id ${scenario-id} --scenario-version-id ${scenario-version-id} --simulator-parameter-overrides 'use_perception_online_evaluator=true,sensing=true'
+webauto ci scenario run --project-id ${project-id} --scenario-id ${scenario-id} --scenario-version-id ${scenario-version-id} --simulator-parameter-overrides 'sensing=true'
 ```
 
 #### Autoware Evaluator
@@ -225,7 +221,6 @@ simulations:
       runtime:
         type: simulator/standard1/amd64/medium
       parameters:
-        use_perception_online_evaluator: "true"
         sensing: "true"
 ```
 

--- a/docs/use_case/annotationless_perception.ja.md
+++ b/docs/use_case/annotationless_perception.ja.md
@@ -5,9 +5,6 @@ perception_online_evaluatorを利用して、Autowareの認識機能(perception)
 以下のPRの機能を持つAutowareが必要。
 <https://github.com/autowarefoundation/autoware.universe/pull/6556>
 
-デフォルトでは起動しないので、launch引数にuse_perception_online_evaluator:=trueを追加する必要がある。
-<https://github.com/autowarefoundation/autoware.universe/pull/6861>
-
 ## 評価方法
 
 `annotationless_perception.launch.py` を使用して評価する。
@@ -129,20 +126,19 @@ Evaluation:
 ##### driving-log-replayer-cli
 
 ```shell
-dlr simulation run -p annotationless_perception -l use_perception_online_evaluator:=true -l annotationless_threshold_file:=${previous_test_result.jsonl_path} -l 'annotationless_pass_range:={"KEY1":VALUE1"[,"KEY2":"VALUE2"...]}'
+dlr simulation run -p annotationless_perception -l annotationless_threshold_file:=${previous_test_result.jsonl_path} -l 'annotationless_pass_range:={"KEY1":VALUE1"[,"KEY2":"VALUE2"...]}'
 
 # example
-dlr simulation run -p annotationless_perception -l use_perception_online_evaluator:=true -l annotationless_threshold_file:=$HOME/out/annotationless/2024-0314-155106/sample/result.jsonl -l 'annotationless_pass_range:={"CAR":{"min":"0.0-1.1","max":"0.0-1.2","mean":"0.5-1.3"},"BUS":{"min":"0.0-1.1","max":"0.0-1.2","mean":"0.5-1.3"}}'
+dlr simulation run -p annotationless_perception -l annotationless_threshold_file:=$HOME/out/annotationless/2024-0314-155106/sample/result.jsonl -l 'annotationless_pass_range:={"CAR":{"min":"0.0-1.1","max":"0.0-1.2","mean":"0.5-1.3"},"BUS":{"min":"0.0-1.1","max":"0.0-1.2","mean":"0.5-1.3"}}'
 ```
 
 ##### WebAutoCLI
 
 ```shell
-webauto ci scenario run --project-id ${project-id} --scenario-id ${scenario-id} --scenario-version-id ${scenario-version-id} --simulator-parameter-overrides 'use_perception_online_evaluator=true,annotationless_threshold_file=${previous_test_result.jsonl_path},annotationless_pass_range:={"KEY1":VALUE1"[,"KEY2":"VALUE2"...]}'
+webauto ci scenario run --project-id ${project-id} --scenario-id ${scenario-id} --scenario-version-id ${scenario-version-id} --simulator-parameter-overrides 'annotationless_threshold_file=${previous_test_result.jsonl_path},annotationless_pass_range:={"KEY1":VALUE1"[,"KEY2":"VALUE2"...]}'
 ```
 
 ##### Autoware Evaluator
-
 .webauto-ci.ymlのsimulatorの設定でparametersに追加する。
 
 ```yaml
@@ -156,7 +152,6 @@ simulations:
       runtime:
         type: simulator/standard1/amd64/medium
       parameters:
-        use_perception_online_evaluator: "true"
         annotationless_threshold_file: ${previous_test_result.jsonl_path}
         annotationless_pass_range:
           KEY1: VALUE1
@@ -200,13 +195,13 @@ autoware の処理を軽くするため、評価に関係のないモジュー�
 #### driving-log-replayer-cli
 
 ```shell
-dlr simulation run -p annotationless_perception -l use_perception_online_evaluator:=true -l sensing:=true
+dlr simulation run -p annotationless_perception -l sensing:=true
 ```
 
 #### WebAutoCLI
 
 ```shell
-webauto ci scenario run --project-id ${project-id} --scenario-id ${scenario-id} --scenario-version-id ${scenario-version-id} --simulator-parameter-overrides 'use_perception_online_evaluator=true,sensing=true'
+webauto ci scenario run --project-id ${project-id} --scenario-id ${scenario-id} --scenario-version-id ${scenario-version-id} --simulator-parameter-overrides 'sensing=true'
 ```
 
 #### Autoware Evaluator
@@ -224,7 +219,6 @@ simulations:
       runtime:
         type: simulator/standard1/amd64/medium
       parameters:
-        use_perception_online_evaluator: "true"
         sensing: "true"
 ```
 

--- a/docs/use_case/annotationless_perception.ja.md
+++ b/docs/use_case/annotationless_perception.ja.md
@@ -139,6 +139,7 @@ webauto ci scenario run --project-id ${project-id} --scenario-id ${scenario-id} 
 ```
 
 ##### Autoware Evaluator
+
 .webauto-ci.ymlのsimulatorの設定でparametersに追加する。
 
 ```yaml

--- a/driving_log_replayer/driving_log_replayer/launch_common.py
+++ b/driving_log_replayer/driving_log_replayer/launch_common.py
@@ -108,6 +108,7 @@ def get_autoware_launch(
     pose_source: str | None = None,
     twist_source: str | None = None,
     perception_mode: str | None = None,
+    use_perception_online_evaluator: str | None = None,
 ) -> launch.actions.IncludeLaunchDescription:
     # autoware launch
     autoware_launch_file = Path(
@@ -135,6 +136,8 @@ def get_autoware_launch(
         launch_args["twist_source"] = twist_source
     if isinstance(perception_mode, str):
         launch_args["perception_mode"] = perception_mode
+    if isinstance(use_perception_online_evaluator, str):
+        launch_args["use_perception_online_evaluator"] = use_perception_online_evaluator
     return launch.actions.IncludeLaunchDescription(
         launch.launch_description_sources.AnyLaunchDescriptionSource(
             autoware_launch_file.as_posix(),

--- a/driving_log_replayer/launch/annotationless_perception.launch.py
+++ b/driving_log_replayer/launch/annotationless_perception.launch.py
@@ -45,6 +45,7 @@ def generate_launch_description() -> launch.LaunchDescription:
     autoware_launch = cmn.get_autoware_launch(
         sensing=LaunchConfiguration("sensing"),
         localization="false",
+        use_perception_online_evaluator="true",
     )
     rviz_node = cmn.get_rviz("autoware.rviz")
     evaluator_node = cmn.get_evaluator_node(

--- a/driving_log_replayer/test/unittest/test_annotationless_perception.py
+++ b/driving_log_replayer/test/unittest/test_annotationless_perception.py
@@ -93,7 +93,7 @@ def test_update_threshold_from_file() -> None:
     # update_threshold_from_file update only keys written in scenario.yaml
     bus_threshold = scenario.Evaluation.Conditions.ClassConditions["BUS"].Threshold
     assert bus_threshold == {
-        "lateral_deviation": DiagValue(max=0.06411),
+        "total_objects_count_r50.00_h10.00": DiagValue(max=0.9868421052631579),
     }
 
 

--- a/driving_log_replayer/test/unittest/test_annotationless_perception.py
+++ b/driving_log_replayer/test/unittest/test_annotationless_perception.py
@@ -93,7 +93,7 @@ def test_update_threshold_from_file() -> None:
     # update_threshold_from_file update only keys written in scenario.yaml
     bus_threshold = scenario.Evaluation.Conditions.ClassConditions["BUS"].Threshold
     assert bus_threshold == {
-        "total_objects_count_r50.00_h10.00": DiagValue(max=0.9868421052631579),
+        "total_objects_count_r50.00_h10.00": DiagValue(max=1.0),
     }
 
 

--- a/driving_log_replayer/test/unittest/test_annotationless_perception.py
+++ b/driving_log_replayer/test/unittest/test_annotationless_perception.py
@@ -34,7 +34,7 @@ def test_scenario() -> None:
     )
     assert scenario.ScenarioName == "sample_annotationless_perception"
     assert scenario.Evaluation.Conditions.ClassConditions["BUS"].Threshold == {
-        "lateral_deviation": DiagValue(max=0.050),
+        "total_objects_count_r50.00_h10.00": DiagValue(max=0.9),
     }
     assert scenario.Evaluation.Conditions.ClassConditions["BUS"].PassRange == {
         "min": (0.0, 2.0),

--- a/sample/annotationless_perception/scenario.ja.yaml
+++ b/sample/annotationless_perception/scenario.ja.yaml
@@ -30,7 +30,7 @@ Evaluation:
       BUS: # classification key
         Threshold:
           # Only lateral_deviation is evaluated.
-          lateral_deviation: { max: 0.050 } # Only max is evaluated.
+          total_objects_count_r50.00_h10.00: { max: 0.9 } # Only max is evaluated.
         PassRange:
           min: 0.0-2.0 # lower[<=1.0]-upper[>=1.0]
           max: 0.0-2.0 # lower[<=1.0]-upper[>=1.0]

--- a/sample/annotationless_perception/scenario.yaml
+++ b/sample/annotationless_perception/scenario.yaml
@@ -30,7 +30,7 @@ Evaluation:
       BUS: # classification key
         Threshold:
           # Only lateral_deviation is evaluated.
-          lateral_deviation: { max: 0.050 } # Only max is evaluated.
+          total_objects_count_r50.00_h10.00: { max: 0.9 } # Only max is evaluated.
         PassRange:
           min: 0.0-2.0 # lower[<=1.0]-upper[>=1.0]
           max: 0.0-2.0 # lower[<=1.0]-upper[>=1.0]


### PR DESCRIPTION
## Types of PR

- [x] Upgrade of existing features

## Description

- set use_perception_online_evaluator=true in `annotationless_perception.launch.py`

## How to review this PR

Please confirm that you can evaluate annotationless_perception without `-l  use_perception_online_evaluator=true` option

```shell
dlr simulation run -p annotationless_perception
```

## Others
