### PR TITLE
feat: use sim time

### DIFF
--- a/driving_log_replayer/driving_log_replayer/launch_common.py
+++ b/driving_log_replayer/driving_log_replayer/launch_common.py
@@ -219,6 +219,7 @@ def get_regex_record_cmd(record_config_name: str, allowlist: str) -> list:
         ).as_posix(),
         "-e",
         allowlist,
+        "--use-sim-time",
     ]
 
 


### PR DESCRIPTION
closes: #57

## Types of PR

- [x] New Features

## Description

- add use-sim-time option to record command

The use-sim-time option of ros2 record was changed to start the record after clock comes. See help for the following command

Previously, if the topic was displayed before the clock came, the time would be 0 seconds, i.e., 1970-01-01T00:00:00, and ros time would jump at the moment the clock came.
Therefore, it was necessary to adjust the record start timing, but now the record side adjusts the record start timing.
It is now equivalent to ros1.

```shell
❯ ros2 bag record -h
usage: ros2 bag record [-h] [-a] [-e REGEX] [-x EXCLUDE] [--include-unpublished-topics] [--include-hidden-topics] [-o OUTPUT] [-s {my_test_plugin,sqlite3,mcap}] [-f {s,a}] [--no-discovery]
...
  --use-sim-time        Use simulation time for message timestamps by subscribing to the /clock topic. Until first /clock message is received, no messages will be written to bag.
```

## How to review this PR

```shell
dlr simulation run -p localization

# check result bag's Start and End are same as input_bag
# example
❯ ros2 bag info input_bag/

Files:             filtered_bag_0.db3
Bag size:          262.8 MiB
Storage id:        sqlite3
Duration:          29.980s
Start:             Apr  5 2022 15:08:00.9 (1649138880.9)
End:               Apr  5 2022 15:08:29.990 (1649138909.990)

~/out/auto/localization/2024-0605-134425/direct
❯ ros2 bag info result_bag

Files:             result_bag_0.db3
Bag size:          17.1 MiB
Storage id:        sqlite3
Duration:          29.829s
Start:             Apr  5 2022 15:08:00.158 (1649138880.158)
End:               Apr  5 2022 15:08:29.988 (1649138909.988)
```

## Others
