### PR TITLE
fix: avoid error that `conf_mat_dict` is referenced before assignment

### DIFF
--- a/driving_log_replayer/scripts/perception_evaluator_node.py
+++ b/driving_log_replayer/scripts/perception_evaluator_node.py
@@ -143,6 +143,7 @@ class PerceptionEvaluator(DLREvaluator):
             self.get_final_result()
             score_dict = {}
             error_dict = {}
+            conf_mat_dict = {}
             analyzer = PerceptionAnalyzer3D(self.__evaluator.evaluator_config)
             analyzer.add(self.__evaluator.frame_results)
             result = analyzer.analyze()


### PR DESCRIPTION
## Types of PR

- [x] Bugfix

## Description

Fix error that `conf_mat_dict` is referenced before assignment

## How to review this PR

## Others
