### PR TITLE
feat: add support of GT TP criteria

### DIFF
--- a/driving_log_replayer/driving_log_replayer/criteria/perception.py
+++ b/driving_log_replayer/driving_log_replayer/criteria/perception.py
@@ -137,17 +137,22 @@ class CriteriaMethod(Enum):
     """
     Enum object represents methods of criteria .
 
-    - NUM_TP: Number of TP (or TN).
-    - LABEL: Whether label is correct or not.
-    - VELOCITY_X_ERROR: Error of x direction velocity [m/s].
-    - VELOCITY_Y_ERROR: Error of y direction velocity [m/s].
-    - SPEED_ERROR: Error of speed [m/s].
-    - YAW_ERROR: Error of yaw [rad].
-    - METRICS_SCORE: Accuracy score for classification, otherwise mAP score is used.
-    - METRICS_SCORE_MAPH: mAPH score.
+    Attributes
+    ----------
+        - NUM_TP: TP (or TN) rate for all estimated and GT objects `NumTP / (NumTP + NumFP)`.
+        - NUM_GT_TP: TP (or TN) rate for all GT objects `NumTP / NumGT`.
+        - LABEL: Whether label is correct or not.
+        - VELOCITY_X_ERROR: Error of x direction velocity [m/s].
+        - VELOCITY_Y_ERROR: Error of y direction velocity [m/s].
+        - SPEED_ERROR: Error of speed [m/s].
+        - YAW_ERROR: Error of yaw [rad].
+        - METRICS_SCORE: Accuracy score for classification, otherwise mAP score is used.
+        - METRICS_SCORE_MAPH: mAPH score.
+
     """
 
     NUM_TP = "num_tp"
+    NUM_GT_TP = "num_gt_tp"
     LABEL = "label"
     VELOCITY_X_ERROR = "velocity_x_error"
     VELOCITY_Y_ERROR = "velocity_y_error"
@@ -272,6 +277,23 @@ class NumTP(CriteriaMethodImpl):
         num_success: int = frame.pass_fail_result.get_num_success()
         num_objects: int = num_success + frame.pass_fail_result.get_num_fail()
         return 100.0 * num_success / num_objects if num_objects != 0 else 100.0
+
+    @property
+    def is_error(self) -> bool:
+        return False
+
+
+class NumGtTP(CriteriaMethodImpl):
+    name = CriteriaMethod.NUM_GT_TP
+
+    def __init__(self, level: CriteriaLevel) -> None:
+        super().__init__(level)
+
+    @staticmethod
+    def calculate_score(frame: PerceptionFrameResult) -> float:
+        num_success: int = frame.pass_fail_result.get_num_success()
+        num_gt: int = len(frame.pass_fail_result.critical_ground_truth_objects)
+        return 100.0 * num_success / num_gt if num_gt != 0 else 100.0
 
     @property
     def is_error(self) -> bool:
@@ -496,7 +518,7 @@ class PerceptionCriteria:
 
     """
 
-    def __init__(
+    def __init__(  # noqa: C901
         self,
         methods: str | list[str] | CriteriaMethod | list[CriteriaMethod] | None = None,
         levels: (
@@ -515,6 +537,8 @@ class PerceptionCriteria:
         for method, level in zip(methods, levels, strict=True):
             if method == CriteriaMethod.NUM_TP:
                 self.methods.append(NumTP(level))
+            elif method == CriteriaMethod.NUM_GT_TP:
+                self.methods.append(NumGtTP(level))
             elif method == CriteriaMethod.LABEL:
                 self.methods.append(Label(level))
             elif method == CriteriaMethod.VELOCITY_X_ERROR:

--- a/driving_log_replayer/driving_log_replayer/perception.py
+++ b/driving_log_replayer/driving_log_replayer/perception.py
@@ -61,6 +61,7 @@ class Criteria(BaseModel):
     CriteriaMethod: (
         Literal[
             "num_tp",
+            "num_gt_tp",
             "label",
             "metrics_score",
             "metrics_score_maph",

--- a/driving_log_replayer/driving_log_replayer/perception_2d.py
+++ b/driving_log_replayer/driving_log_replayer/perception_2d.py
@@ -27,7 +27,7 @@ from driving_log_replayer.scenario import Scenario
 
 class Conditions(BaseModel):
     PassRate: number
-    CriteriaMethod: Literal["num_tp", "metrics_score"] | None = None
+    CriteriaMethod: Literal["num_tp", "num_gt_tp", "label", "metrics_score"] | None = None
     CriteriaLevel: Literal["perfect", "hard", "normal", "easy"] | number | None = None
     TargetCameras: dict[str, int]
 

--- a/driving_log_replayer/driving_log_replayer/traffic_light.py
+++ b/driving_log_replayer/driving_log_replayer/traffic_light.py
@@ -127,9 +127,9 @@ class Filter(BaseModel):
 
 class Criteria(BaseModel):
     PassRate: number
-    CriteriaMethod: (
-        Literal["num_tp", "label", "metrics_score", "metrics_score_maph"] | list[str] | None
-    ) = None
+    CriteriaMethod: Literal["num_tp", "num_gt_tp", "label", "metrics_score"] | list[str] | None = (
+        None
+    )
     CriteriaLevel: (
         Literal["perfect", "hard", "normal", "easy"] | list[str] | number | list[number] | None
     ) = None


### PR DESCRIPTION
## Types of PR

- [x] New Features

## Description

Related to [TIER IV INTERNAL LINK](https://star4.slack.com/archives/C02G6HT8TNX/p1719459096370449?thread_ts=1718065046.566139&cid=C02G6HT8TNX).
Add a new criteria named `NumGtTP` only considering whether all ground truths are TP even if there are any FP objects.

In scenarios, please specify as follows:

```yaml
Criterion:
  - PassRate: ...
    CriteriaMethod: num_gt_tp
    CriteriaLevel: ...
    Filter:
      Distance: ...
```

## How to review this PR

## Others
