### PR TITLE
fix: resolve invalid access to `critical_ground_truth_objects`

### DIFF
--- a/driving_log_replayer/driving_log_replayer/criteria/perception.py
+++ b/driving_log_replayer/driving_log_replayer/criteria/perception.py
@@ -292,7 +292,9 @@ class NumGtTP(CriteriaMethodImpl):
     @staticmethod
     def calculate_score(frame: PerceptionFrameResult) -> float:
         num_success: int = frame.pass_fail_result.get_num_success()
-        num_gt: int = len(frame.pass_fail_result.critical_ground_truth_objects)
+        num_gt: int = len(frame.pass_fail_result.tp_object_results) + len(
+            frame.pass_fail_result.fn_objects,
+        )
         return 100.0 * num_success / num_gt if num_gt != 0 else 100.0
 
     @property


### PR DESCRIPTION
## Types of PR

- [x] Bugfix

## Description

This PR fixes invalid attribute access to `PassFailResult.critical_ground_truth_objects` updated in https://github.com/tier4/autoware_perception_evaluation/pull/179.

## How to review this PR

Run scenario with criteria: `num_gt_tp`.

## Others
