### PR TITLE
fix(perception): resolve invalid access to `None`

### DIFF
--- a/driving_log_replayer/driving_log_replayer/perception_eval_conversions.py
+++ b/driving_log_replayer/driving_log_replayer/perception_eval_conversions.py
@@ -151,7 +151,7 @@ def dynamic_objects_to_ros_points(
     points: list[Point] = []
     for obj in container:
         point = Point()
-        if type(obj) == DynamicObjectWithPerceptionResult:
+        if isinstance(obj, DynamicObjectWithPerceptionResult):
             if tp_gt:
                 if obj.ground_truth_object is not None:
                     # tpのgtを出したい場合、tpならば必ずground_truthのペアがいる
@@ -162,7 +162,7 @@ def dynamic_objects_to_ros_points(
                 point.x = obj.estimated_object.state.position[0]
                 point.y = obj.estimated_object.state.position[1]
                 point.z = obj.estimated_object.state.position[2]
-        if type(obj) == DynamicObject:
+        if isinstance(obj, DynamicObject):
             point.x = obj.state.position[0]
             point.y = obj.state.position[1]
             point.z = obj.state.position[2]

--- a/driving_log_replayer/driving_log_replayer/perception_eval_conversions.py
+++ b/driving_log_replayer/driving_log_replayer/perception_eval_conversions.py
@@ -272,7 +272,7 @@ def calc_position_error(
 
 def fill_xyz(tuple_: tuple[float, float, float] | None) -> dict:
     if tuple_ is None:
-        return {"x": None, "y": None, "z": None}
+        return {"x": np.nan, "y": np.nan, "z": np.nan}
     return {
         "x": tuple_[0],
         "y": tuple_[1],
@@ -282,7 +282,7 @@ def fill_xyz(tuple_: tuple[float, float, float] | None) -> dict:
 
 def fill_xyzw(tuple_: tuple[float, float, float, float] | None) -> dict:
     if tuple_ is None:
-        return {"x": None, "y": None, "z": None, "w": None}
+        return {"x": np.nan, "y": np.nan, "z": np.nan, "w": np.nan}
     return {
         "x": tuple_[0],
         "y": tuple_[1],
@@ -293,7 +293,7 @@ def fill_xyzw(tuple_: tuple[float, float, float, float] | None) -> dict:
 
 def fill_xyzw_quat(q: Quaternion | None) -> dict:
     if q is None:
-        return {"x": None, "y": None, "z": None, "w": None}
+        return {"x": np.nan, "y": np.nan, "z": np.nan, "w": np.nan}
     return {
         "x": q.x,
         "y": q.y,

--- a/driving_log_replayer/driving_log_replayer/perception_eval_conversions.py
+++ b/driving_log_replayer/driving_log_replayer/perception_eval_conversions.py
@@ -270,7 +270,9 @@ def calc_position_error(
     return tuple(map(lambda x, y: x - y, tuple1, tuple2))
 
 
-def fill_xyz(tuple_: tuple[float, float, float]) -> dict:
+def fill_xyz(tuple_: tuple[float, float, float] | None) -> dict:
+    if tuple_ is None:
+        return {"x": None, "y": None, "z": None}
     return {
         "x": tuple_[0],
         "y": tuple_[1],
@@ -278,7 +280,9 @@ def fill_xyz(tuple_: tuple[float, float, float]) -> dict:
     }
 
 
-def fill_xyzw(tuple_: tuple[float, float, float, float]) -> dict:
+def fill_xyzw(tuple_: tuple[float, float, float, float] | None) -> dict:
+    if tuple_ is None:
+        return {"x": None, "y": None, "z": None, "w": None}
     return {
         "x": tuple_[0],
         "y": tuple_[1],
@@ -287,7 +291,9 @@ def fill_xyzw(tuple_: tuple[float, float, float, float]) -> dict:
     }
 
 
-def fill_xyzw_quat(q: Quaternion) -> dict:
+def fill_xyzw_quat(q: Quaternion | None) -> dict:
+    if q is None:
+        return {"x": None, "y": None, "z": None, "w": None}
     return {
         "x": q.x,
         "y": q.y,


### PR DESCRIPTION
## Types of PR

- [x] Bugfix

## Description

Related to https://github.com/tier4/driving_log_replayer/pull/452.

Fix following error while converting evaluation results:

```shell
[perception_evaluator_node.py-68]   File "/home/autoware/pilot-auto/install/driving_log_replayer/lib/driving_log_replayer/perception_evaluator_node.py", line 265, in perception_cb
[perception_evaluator_node.py-68]     marker_ground_truth, marker_results = self._result.set_frame(
[perception_evaluator_node.py-68]   File "/home/autoware/pilot-auto/install/driving_log_replayer/local/lib/python3.10/dist-packages/driving_log_replayer/perception.py", line 172, in set_frame
[perception_evaluator_node.py-68]     self._frame[criterion.name] = criterion.set_frame(frame)
[perception_evaluator_node.py-68]   File "/home/autoware/pilot-auto/install/driving_log_replayer/local/lib/python3.10/dist-packages/driving_log_replayer/perception.py", line 133, in set_frame
[perception_evaluator_node.py-68]     "Objects": FrameDescriptionWriter.extract_pass_fail_objects_description(
[perception_evaluator_node.py-68]   File "/home/autoware/pilot-auto/install/driving_log_replayer/local/lib/python3.10/dist-packages/driving_log_replayer/perception_eval_conversions.py", line 503, in extract_pass_fail_objects_description
[perception_evaluator_node.py-68]     fn_obj_description = FrameDescriptionWriter.object_to_description(fn_gt)
[perception_evaluator_node.py-68]   File "/home/autoware/pilot-auto/install/driving_log_replayer/local/lib/python3.10/dist-packages/driving_log_replayer/perception_eval_conversions.py", line 330, in object_to_description
[perception_evaluator_node.py-68]     "velocity": fill_xyz(obj.state.velocity),
[perception_evaluator_node.py-68]   File "/home/autoware/pilot-auto/install/driving_log_replayer/local/lib/python3.10/dist-packages/driving_log_replayer/perception_eval_conversions.py", line 275, in fill_xyz
[perception_evaluator_node.py-68]     "x": tuple_[0],
[perception_evaluator_node.py-68] TypeError: 'NoneType' object is not subscriptable
```

### Test results on evaluator

- [TIER IV INTERNAL LINK](https://evaluation.tier4.jp/evaluation/reports/a09006f7-a9bd-5365-ae89-3b717306f49a?project_id=prd_jt)
- [TIER IV INTERNAL LINK](https://evaluation.tier4.jp/evaluation/reports/e5b3073f-68a7-5bc7-aa5a-a340dcbd613b?project_id=prd_jt)
- [TIER IV INTERNAL LINK](https://evaluation.tier4.jp/evaluation/reports/89e4c44e-630c-5308-b36a-ce6a7fad8ad4?project_id=prd_jt)
- [TIER IV INTERNAL LINK](https://evaluation.tier4.jp/evaluation/reports/94d4fe82-9aff-586b-8298-8d7a3723c53b?project_id=prd_jt)
- [TIER IV INTERNAL LINK](https://evaluation.tier4.jp/evaluation/reports/62e8cbe9-4fe8-5f01-9e14-81905043bba7?project_id=prd_jt)
- [TIER IV INTERNAL LINK](https://evaluation.tier4.jp/evaluation/reports/baecd4c1-769d-594b-90f8-0a810ff2d392?project_id=prd_jt)
- [TIER IV INTERNAL LINK](https://evaluation.tier4.jp/evaluation/reports/4ba9b328-88b2-5103-acd1-6c4dba3e8377?project_id=prd_jt)

## How to review this PR

## Others
