### PR TITLE
fix(traffic_light): remove autoware_perception_msgs in traffic_light

### DIFF
--- a/driving_log_replayer/scripts/traffic_light_evaluator_node.py
+++ b/driving_log_replayer/scripts/traffic_light_evaluator_node.py
@@ -162,7 +162,7 @@ class TrafficLightEvaluator(DLREvaluator):
             label = self.__evaluator.evaluator_config.label_converter.convert_label(
                 get_traffic_light_label_str(signal.elements),
             )
-            confidence: float = max(signal.elements, key=lambda x: x.confidence)
+            confidence: float = max(signal.elements, key=lambda x: x.confidence).confidence
             signal_pos = self.get_traffic_light_pos(signal.traffic_light_group_id, cam2map)
             # debug self.get_logger().error(f"{signal_pos=}")
 


### PR DESCRIPTION
## Types of PR

- [x] Bugfix

## Description
Change types from `autoware_perception_msgs.msg._traffic_light_element.TrafficLightElement` to `float` to analyze `auto-evalator`.
Related links: https://github.com/tier4/auto-evaluator/pull/206

## How to review this PR
None. But I checked this on [`Evaluator`](https://evaluation.ci.tier4.jp/evaluation/reports/ca2e697d-2a54-5c19-841b-3ba89fca7aef?project_id=prd_jt) and local `auto-evalator`

## Others
