### PR TITLE
feat(annotationless_perception): rename input diag topics

### DIFF
--- a/docs/use_case/annotationless_perception.en.md
+++ b/docs/use_case/annotationless_perception.en.md
@@ -12,7 +12,7 @@ Launching the file executes the following steps:
 
 1. Execute launch of evaluation node (`annotationless_perception_evaluator_node`), `logging_simulator.launch` file and `ros2 bag play` command
 2. Autoware receives sensor data output from input rosbag and the perception module performs recognition.
-3. The perception_online_evaluator publishes diagnostic topic to `/diagnostic/perception_online_evaluator/metrics`
+3. The perception_online_evaluator publishes diagnostic topic to `/perception/perception_online_evaluator/metrics`
 4. The evaluation node subscribes to the topic and evaluates data. The result is dumped into a file.
 5. When the playback of the rosbag is finished, Autoware's launch is automatically terminated, and the evaluation is completed.
 
@@ -32,7 +32,7 @@ The following two values specified in the scenario or launch argument are used t
 - Threshold
 - PassRange(Coefficient to correct threshold)
 
-Success or failure is determined for each status.name in `/diagnostic/perception_online_evaluator/metrics` according to the following rules.
+Success or failure is determined for each status.name in `/perception/perception_online_evaluator/metrics` according to the following rules.
 Items for which no threshold is set (min, max, mean) are always judged as normal. Only those items for which a threshold is specified are subject to evaluation.
 
 #### min
@@ -68,7 +68,7 @@ Subscribed topics:
 
 | Topic name                                      | Data type                             |
 | ----------------------------------------------- | ------------------------------------- |
-| /diagnostic/perception_online_evaluator/metrics | diagnostic_msgs::msg::DiagnosticArray |
+| /perception/perception_online_evaluator/metrics | diagnostic_msgs::msg::DiagnosticArray |
 
 Published topics:
 

--- a/docs/use_case/annotationless_perception.ja.md
+++ b/docs/use_case/annotationless_perception.ja.md
@@ -12,7 +12,7 @@ launch を立ち上げると以下のことが実行され、評価される。
 
 1. launch で評価ノード(`annotationless_perception_evaluator_node`)と `logging_simulator.launch`、`ros2 bag play`コマンドを立ち上げる
 2. bag から出力されたセンサーデータを autoware が受け取って、perception モジュールが認識を行う
-3. perception_online_evaluator が `/diagnostic/perception_online_evaluator/metrics`に診断結果を出力する
+3. perception_online_evaluator が `/perception/perception_online_evaluator/metrics`に診断結果を出力する
 4. 評価ノードが topic を subscribe して、各基準を満たしているかを判定して結果をファイルに記録する
 5. bag の再生が終了すると自動で launch が終了して評価が終了する
 
@@ -32,7 +32,7 @@ topic の subscribe 1 回につき、認識クラス毎に以下に記述する�
 - 閾値
 - 合格範囲(閾値を補正する係数)
 
-`/diagnostic/perception_online_evaluator/metrics` のstatus.name毎に以下のルールに従い成否の判定が行われる。
+`/perception/perception_online_evaluator/metrics` のstatus.name毎に以下のルールに従い成否の判定が行われる。
 閾値が設定されてない項目(min, max, mean)に関しては常に正常と判定される。指定があるもののみが評価対象になる。
 
 #### min
@@ -68,7 +68,7 @@ Subscribed topics:
 
 | Topic name                                      | Data type                             |
 | ----------------------------------------------- | ------------------------------------- |
-| /diagnostic/perception_online_evaluator/metrics | diagnostic_msgs::msg::DiagnosticArray |
+| /perception/perception_online_evaluator/metrics | diagnostic_msgs::msg::DiagnosticArray |
 
 Published topics:
 

--- a/driving_log_replayer/launch/annotationless_perception.launch.py
+++ b/driving_log_replayer/launch/annotationless_perception.launch.py
@@ -29,7 +29,7 @@ RECORD_TOPIC_REGEX = """^/clock$\
 |^/perception/object_recognition/objects$\
 |^/perception/object_recognition/tracking/multi_object_tracker/debug/.*\
 |^/perception/object_recognition/detection/.*/debug/pipeline_latency_ms$\
-|^/diagnostic/perception_online_evaluator/.*\
+|^/perception/perception_online_evaluator/.*\
 """
 
 

--- a/driving_log_replayer/scripts/annotationless_perception_evaluator_node.py
+++ b/driving_log_replayer/scripts/annotationless_perception_evaluator_node.py
@@ -47,7 +47,7 @@ class AnnotationlessPerceptionEvaluator(DLREvaluator):
 
         self.__sub_diagnostics = self.create_subscription(
             DiagnosticArray,
-            "/diagnostic/perception_online_evaluator/metrics",
+            "/perception/perception_online_evaluator/metrics",
             self.diagnostics_cb,
             1,
         )


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [x] Upgrade of existing features
- [ ] Bugfix

## Description

https://github.com/autowarefoundation/autoware.universe/pull/8152
https://star4.slack.com/archives/C03QW0GU6P7/p1721700599221729

/dignostic/*と/diagnostics/*かつ、今後diag(閾値と比較)とmetrics(値のみの計算)を分離する話があるため、トピックのリネームをしています。
plannig, controlにも同様な変更が必要です :bow: 

## How to review this PR

## Others
