### PR TITLE
fix: fix diag index error

### DIFF
--- a/driving_log_replayer/scripts/obstacle_segmentation_evaluator_node.py
+++ b/driving_log_replayer/scripts/obstacle_segmentation_evaluator_node.py
@@ -303,6 +303,8 @@ class ObstacleSegmentationEvaluator(DLREvaluator):
                     self.__latest_stop_reasons.append(message_to_ordereddict(msg_reason))
 
     def diag_cb(self, msg: DiagnosticArray) -> None:
+        if not msg.status:
+            return
         diag_status: DiagnosticStatus = msg.status[0]
         if diag_status.name == TARGET_DIAG_NAME:
             return


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Description
Without diag msgs, msg.status[0] causes the following error
Fixed to work around this.
```
[obstacle_segmentation_evaluator_node.py-75]   File "/home/autoware/pilot-auto.x1/install/driving_log_replayer/lib/driving_log_replayer/obstacle_segmentation_evaluator_node.py", line 306, in diag_cb
[obstacle_segmentation_evaluator_node.py-75]     diag_status: DiagnosticStatus = msg.status[0]
[obstacle_segmentation_evaluator_node.py-75] IndexError: list index out of range
[component_container_mt-1] [INFO] [1721737631.943992032] [perception.obstacle_segmen
```
## How to review this PR

## Others
Autoware Evaluator
before [TIER IV INTERNAL LINK](https://evaluation.tier4.jp/evaluation/reports/04bca0a6-2376-5dfd-a509-3da2b9821227?project_id=X8ft5pPN)
after [TIER IV INTERNAL LINK](https://evaluation.tier4.jp/evaluation/reports/fed5c090-70a5-5ba3-9080-e5fb5c28c52d?project_id=X8ft5pPN)