### PR TITLE
fix: use `pyquaterion` instead of `tf_transformations`

### DIFF
--- a/driving_log_replayer/package.xml
+++ b/driving_log_replayer/package.xml
@@ -36,7 +36,6 @@
   <exec_depend>driving_log_replayer_analyzer</exec_depend>
   <exec_depend>lanelet2_extension_python</exec_depend>
   <exec_depend>perception_eval</exec_depend>
-  <exec_depend>python-transforms3d-pip</exec_depend>
   <exec_depend>python3-jsonschema</exec_depend>
   <exec_depend>python3-pandas</exec_depend>
   <exec_depend>python3-simplejson</exec_depend>
@@ -46,7 +45,6 @@
   <exec_depend>ros2_numpy</exec_depend>
   <exec_depend>rosbag2_storage_mcap</exec_depend>
   <exec_depend>rosidl_runtime_py</exec_depend>
-  <exec_depend>tf_transformations</exec_depend>
 
   <!-- to avoid rosdep install error -->
   <!-- <exec_depend>autoware_launch</exec_depend> -->

--- a/driving_log_replayer/scripts/debug/calc_transform_node.py
+++ b/driving_log_replayer/scripts/debug/calc_transform_node.py
@@ -22,6 +22,7 @@ from geometry_msgs.msg import Quaternion
 from geometry_msgs.msg import Transform
 from geometry_msgs.msg import TransformStamped
 from geometry_msgs.msg import Vector3
+from pyquaternion import Quaternion as PyQuaternion
 import rclpy
 from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
 from rclpy.clock import Clock
@@ -36,7 +37,6 @@ from tf2_ros import Buffer
 from tf2_ros import TransformBroadcaster
 from tf2_ros import TransformException
 from tf2_ros import TransformListener
-from tf_transformations import quaternion_from_euler
 
 
 class CalcTransformNode(Node):
@@ -52,9 +52,9 @@ class CalcTransformNode(Node):
         self._tf_listener = TransformListener(self._tf_buffer, self, spin_thread=True)
 
         self._translation = Vector3(x=10.0, y=10.0, z=0.0)
-        q = quaternion_from_euler(0.0, 0.0, -pi / 2)
-        self.get_logger().error(f"{q[0]=}, {q[1]=}, {q[1]=}, {q[2]=}")
-        self._rotation = Quaternion(x=q[0], y=q[1], z=q[2], w=q[3])
+        q = PyQuaternion(axis=[0, 0, 1], angle=-pi / 2)
+        self.get_logger().error(f"{q.x=}, {q.y=}, {q.z=}, {q.z=}")
+        self._rotation = Quaternion(x=q.x, y=q.y, z=q.z, w=q.w)
 
         self._timer_group = MutuallyExclusiveCallbackGroup()
         self._timer = self.create_timer(

--- a/driving_log_replayer/test/unittest/test_evaluator.py
+++ b/driving_log_replayer/test/unittest/test_evaluator.py
@@ -74,9 +74,9 @@ def test_transform_stamped_with_euler_angle() -> None:
             },
         },
         "rotation_euler": {
-            "roll": -0.022698392435205317,
-            "pitch": -0.04389133881352741,
-            "yaw": -2.7016745033573883,
+            "roll": 0.0018567112468680289,
+            "pitch": 0.049375005486871286,
+            "yaw": -2.7022185830310637,
         },
     }
     assert DLREvaluator.transform_stamped_with_euler_angle(tf) == dict_tf_euler

--- a/driving_log_replayer/test/unittest/test_obstacle_segmentation.py
+++ b/driving_log_replayer/test/unittest/test_obstacle_segmentation.py
@@ -39,7 +39,6 @@ from shapely.geometry import Polygon
 from shapely.geometry.polygon import orient
 from std_msgs.msg import ColorRGBA
 from std_msgs.msg import Header
-from tf_transformations import quaternion_from_euler
 from visualization_msgs.msg import Marker
 
 from driving_log_replayer.obstacle_segmentation import Detection
@@ -532,13 +531,13 @@ def test_non_detection_success(
 def test_transform_proposed_area() -> None:
     header_base_link = Header(frame_id="base_link")
     header_map = Header(frame_id="map")
-    q = quaternion_from_euler(0.0, 0.0, -pi / 2)
+    q = PyQuaternion(axis=[0, 0, 1], angle=-pi / 2)
     map_to_baselink = TransformStamped(
         header=header_map,
         child_frame_id="base_link",
         transform=Transform(
             translation=Vector3(x=10.0, y=10.0, z=0.0),
-            rotation=Quaternion(x=q[0], y=q[1], z=q[2], w=q[3]),
+            rotation=Quaternion(x=q.x, y=q.y, z=q.z, w=q.w),
         ),
     )
     proposed_area = ProposedAreaCondition(


### PR DESCRIPTION
## Types of PR

- [x] Bugfix

## Description

This PR updates to use `pyquaterion` instead of `tf_trasnformations` in order to avoid the following error:

```shell
[perception_evaluator_node.py-66] Traceback (most recent call last):
[perception_evaluator_node.py-66]   File "/home/autoware/pilot-auto/install/driving_log_replayer/lib/driving_log_replayer/perception_evaluator_node.py", line 42, in <module>
[perception_evaluator_node.py-66]     from driving_log_replayer.evaluator import DLREvaluator
[perception_evaluator_node.py-66]   File "/home/autoware/pilot-auto/install/driving_log_replayer/local/lib/python3.10/dist-packages/driving_log_replayer/evaluator.py", line 45, in <module>
[perception_evaluator_node.py-66]     from tf_transformations import euler_from_quaternion
[perception_evaluator_node.py-66]   File "/opt/ros/humble/lib/python3.10/site-packages/tf_transformations/__init__.py", line 47, in <module>
[perception_evaluator_node.py-66]     import transforms3d
[perception_evaluator_node.py-66]   File "/usr/lib/python3/dist-packages/transforms3d/__init__.py", line 10, in <module>
[perception_evaluator_node.py-66]     from . import quaternions
[perception_evaluator_node.py-66]   File "/usr/lib/python3/dist-packages/transforms3d/quaternions.py", line 26, in <module>
[perception_evaluator_node.py-66]     _MAX_FLOAT = np.maximum_sctype(np.float)
[perception_evaluator_node.py-66]   File "/home/autoware/.local/lib/python3.10/site-packages/numpy/__init__.py", line 324, in __getattr__
[perception_evaluator_node.py-66]     raise AttributeError(__former_attrs__[attr])
[perception_evaluator_node.py-66] AttributeError: module 'numpy' has no attribute 'float'.
[perception_evaluator_node.py-66] `np.float` was a deprecated alias for the builtin `float`. To avoid this error in existing code, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
[perception_evaluator_node.py-66] The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
[perception_evaluator_node.py-66]     https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations. Did you mean: 'cfloat'?
```

## How to review this PR

## Others
