### PR TITLE
fix(driving_log_replayer): add autoware prefix for map_height_fitter package

### DIFF
--- a/driving_log_replayer/driving_log_replayer/launch_common.py
+++ b/driving_log_replayer/driving_log_replayer/launch_common.py
@@ -148,7 +148,7 @@ def get_autoware_launch(
 def get_map_height_fitter(launch_service: str = "true") -> launch.actions.IncludeLaunchDescription:
     # map_height_fitter launch
     fitter_launch_file = Path(
-        get_package_share_directory("map_height_fitter"),
+        get_package_share_directory("autoware_map_height_fitter"),
         "launch",
         "map_height_fitter.launch.xml",
     )


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [x] Upgrade of existing features
- [ ] Bugfix

## Description
This PR will add `autoware_` prefix for `map_height_fitter` in `launch_common.py`' `get_map_height_fitter`.

This is for https://github.com/autowarefoundation/autoware.universe/pull/8421

## How to review this PR

## Others
