### PR TITLE
fix: Handle missing scenario file and invalid Datasets

### DIFF
--- a/driving_log_replayer_cli/core/config.py
+++ b/driving_log_replayer_cli/core/config.py
@@ -86,7 +86,7 @@ def remove_config(profile: str, filepath: Path | None = None) -> Config:
 
 def _load_from_file(filepath: Path) -> dict[str, dict]:
     if not filepath.exists():
-        error_msg = "Configuration file is not found."
+        error_msg = f"Configuration file {filepath} was not found."
         raise UserError(error_msg)
     with filepath.open() as fp:
         return toml.load(fp)

--- a/driving_log_replayer_cli/simulation/run.py
+++ b/driving_log_replayer_cli/simulation/run.py
@@ -46,6 +46,7 @@ def run(
         output_case = output_dir_by_time.joinpath(dataset_path.name)
         scenario_file = get_scenario_file(dataset_path, base_scenario_path)
         if scenario_file is None:
+            termcolor.cprint("No scenario file found: {scenario_file}", "red")
             continue
         scenario = load_scenario(scenario_file)
         launch_cmd = None
@@ -254,7 +255,10 @@ def cmd_use_t4_dataset(
     t4_dataset_base_path = dataset_path.joinpath("t4_dataset")
     try:
         t4_datasets: Datasets = Datasets(Datasets=scenario.Evaluation["Datasets"])
-    except ValidationError:
+    except ValidationError as e:
+        termcolor.cprint(
+            f"Can't parse Datasets from {t4_dataset_base_path} due to an exception: {e}", "red"
+        )
         return None
     else:
         is_database_evaluation = bool(len(t4_datasets.Datasets) > 1)
@@ -269,7 +273,8 @@ def cmd_use_t4_dataset(
             t4_dataset_path = t4_dataset_base_path.joinpath(key)
             if not t4_dataset_path.exists():
                 termcolor.cprint(
-                    f"t4_dataset: {key} does not exist",
+                    f"t4_dataset: {key} does not exist in {t4_dataset_base_path}."
+                    f"Checked path {t4_dataset_path}",
                     "red",
                 )
                 continue

--- a/driving_log_replayer_cli/simulation/run.py
+++ b/driving_log_replayer_cli/simulation/run.py
@@ -46,7 +46,7 @@ def run(
         output_case = output_dir_by_time.joinpath(dataset_path.name)
         scenario_file = get_scenario_file(dataset_path, base_scenario_path)
         if scenario_file is None:
-            termcolor.cprint("No scenario file found: {scenario_file}", "red")
+            termcolor.cprint(f"No scenario file found: {scenario_file}", "red")
             continue
         scenario = load_scenario(scenario_file)
         launch_cmd = None


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [x] Upgrade of existing features
- [ ] Bugfix

## Description
1. When a scenario file is missing, the code now prints a red error message and continues to the next dataset.
2. When parsing the Datasets from the t4_dataset path, if there is an exception, the code now prints a red error message with the exception details.
