### PR TITLE
feat: add covariance information in jsonl

### DIFF
--- a/driving_log_replayer/driving_log_replayer/perception_eval_conversions.py
+++ b/driving_log_replayer/driving_log_replayer/perception_eval_conversions.py
@@ -369,10 +369,9 @@ class FrameDescriptionWriter:
                 "pose_covariance": [],
                 "twist_covariance": [],
             }
-        # TODO
-        # wait for covariance calculation implementation
-        pose_covariance = []
-        twist_covariance = []
+
+        pose_covariance = obj.pose_covariance.tolist() if obj.has_pose_covariance else []
+        twist_covariance = obj.twist_covariance.tolist() if obj.has_twist_covariance else []
         return {
             "pose_covariance": pose_covariance,
             "twist_covariance": twist_covariance,

--- a/driving_log_replayer/driving_log_replayer/perception_eval_conversions.py
+++ b/driving_log_replayer/driving_log_replayer/perception_eval_conversions.py
@@ -370,8 +370,12 @@ class FrameDescriptionWriter:
                 "twist_covariance": [],
             }
 
-        pose_covariance = obj.pose_covariance.tolist() if obj.has_pose_covariance else []
-        twist_covariance = obj.twist_covariance.tolist() if obj.has_twist_covariance else []
+        pose_covariance = (
+            obj.state.pose_covariance.tolist() if obj.state.has_pose_covariance else []
+        )
+        twist_covariance = (
+            obj.state.twist_covariance.tolist() if obj.state.has_twist_covariance else []
+        )
         return {
             "pose_covariance": pose_covariance,
             "twist_covariance": twist_covariance,

--- a/driving_log_replayer/scripts/perception_evaluator_node.py
+++ b/driving_log_replayer/scripts/perception_evaluator_node.py
@@ -215,6 +215,8 @@ class PerceptionEvaluator(DLREvaluator):
                 velocity=eval_conversions.velocity_from_ros_msg(
                     perception_object.kinematics.twist_with_covariance.twist.linear,
                 ),
+                pose_covariance=perception_object.kinematics.pose_with_covariance.covariance,
+                twist_covariance=perception_object.kinematics.twist_with_covariance.covariance,
                 semantic_score=most_probable_classification.probability,
                 semantic_label=label,
                 uuid=uuid,


### PR DESCRIPTION
## Types of PR

- [x] New Features
- [ ] Upgrade of existing features
- [ ] Bugfix

## Description

Author wants to add covariance information into jsonl. This will help to evaluate centerpoint_sigma model. See https://tier4.atlassian.net/browse/RT1-8002 for TIER IV members.

This PR must merged after https://github.com/tier4/autoware_perception_evaluation/pull/190.

## How to review this PR
Run evaluator and see the result.

## Others
