### PR TITLE
fix: check DiagnosticArray status length

### DIFF
--- a/driving_log_replayer/scripts/yabloc_evaluator_node.py
+++ b/driving_log_replayer/scripts/yabloc_evaluator_node.py
@@ -38,6 +38,8 @@ class YabLocEvaluator(DLREvaluator):
         )
 
     def diagnostics_cb(self, msg: DiagnosticArray) -> None:
+        if len(msg.status) == 0:
+            return
         diag_status = msg.status[0]
         if diag_status.name != TARGET_DIAG_NAME:
             return


### PR DESCRIPTION
## Types of PR

- [x] Bugfix

## Description

- check status length if length == 0 return

## How to review this PR

```shell
webauto ci scenario run --project-id prd_jt --scenario-id a0bed3d4-be44-4ca4-a21b-ff7bccfb9d48 --scenario-version-id 2

..,
---
result              	true
log_path            	/home/hyt/.webauto/simulation/data/data_20241009172202_2851366249/log
duration            	145.57 sec
```

## Others
